### PR TITLE
fix: production bugs, latency, RIB key, robust holder anchoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check with Clippy
-        run: cargo clippy
+        run: cargo clippy --all-features --all-targets
 
   test:
     name: cargo test

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ models/*
 !models/.gitkeep
 la_taupe_debug
 .ruby-version
+gitignored/
+**/truth.csv

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -3,11 +3,12 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::file_utils::{list_img_in_pdf, pdf_to_img_bytes};
+use crate::provenance::{Engine, Provenance, Route};
 use crate::rib::Rib;
 use crate::{
     datamatrix::fetch_datamatrix,
     file_utils::{bytes_to_img, pdf_bytes_to_string},
-    ocr::image_bytes_to_rib,
+    ocr::image_bytes_to_rib_traced,
     twoddoc::{ddoc::Ddoc, parse},
 };
 
@@ -44,34 +45,61 @@ pub enum Type {
 }
 
 fn vec_to_rib(content: Vec<u8>, name: &str) -> Result<Option<Rib>, String> {
+    vec_to_rib_traced(content, name, &mut Provenance::default())
+}
+
+/// Même aiguillage, en consignant la branche empruntée et la stratégie qui a abouti.
+/// Une seule implémentation, pour que la mesure porte sur le code de production.
+pub fn vec_to_rib_traced(
+    content: Vec<u8>,
+    name: &str,
+    provenance: &mut Provenance,
+) -> Result<Option<Rib>, String> {
     let filetype = tree_magic_mini::from_u8(&content);
 
     if filetype == "application/pdf" {
         let string_rib = pdf_bytes_to_string(content.clone());
 
         if !string_rib.trim().is_empty() {
+            provenance.route = Some(Route::PdfText);
+
             let rib = Rib::parse(string_rib);
             if rib.is_some() {
+                provenance.engine = Some(Engine::PdfText);
                 Ok(rib)
             // if there is only one image in PDF, it could be a scan of a RIB
             // with some poorly parse text.
             // don't try it for all as it is costly
             } else if list_img_in_pdf(content.clone()) == 1 {
+                provenance.route = Some(Route::PdfImage);
+
                 let img = pdf_to_img_bytes(content);
-                Ok(image_bytes_to_rib(img, name))
+                Ok(image_bytes_to_rib_traced(img, name, provenance))
             } else {
                 Ok(None)
             }
         } else {
+            provenance.route = Some(Route::PdfImage);
+
             let img = pdf_to_img_bytes(content);
-            Ok(image_bytes_to_rib(img, name))
+            Ok(image_bytes_to_rib_traced(img, name, provenance))
         }
     } else if filetype == "image/png" || filetype == "image/jpeg" {
-        Ok(image_bytes_to_rib(content, name))
+        provenance.route = Some(Route::Image);
+
+        Ok(image_bytes_to_rib_traced(content, name, provenance))
     } else if filetype == "text/plain" {
+        provenance.route = Some(Route::PlainText);
+
         let string_rib = String::from_utf8(content)
             .map_err(|_| "Failed to convert bytes to string".to_string())?;
-        Ok(Rib::parse(string_rib))
+
+        let rib = Rib::parse(string_rib);
+        if rib.is_some() {
+            provenance.engine = Some(Engine::PdfText);
+        }
+
+        Ok(rib)
     } else {
         Err(format!("Unsupported file type: {}", filetype))
     }

--- a/src/http/analyze.rs
+++ b/src/http/analyze.rs
@@ -113,7 +113,26 @@ async fn handle_response(mut resp: Response, hint: Option<Hint>) -> HttpResponse
             });
     }
 
-    match Analysis::try_from((bytes, hint, "remote_file")) {
+    // L'analyse dure de quelques secondes à plusieurs dizaines : la laisser dans le
+    // futur bloquerait un worker actix et toutes les connexions qu'il multiplexe.
+    // web::block la porte sur le pool de threads bloquants.
+    let outcome = web::block(move || Analysis::try_from((bytes, hint, "remote_file"))).await;
+
+    let outcome = match outcome {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            log::error!("analysis task failed: {}", e);
+            return HttpResponse::InternalServerError()
+                .content_type(ContentType::json())
+                .json(AnalysisError {
+                    upstream_status_code: None,
+                    upstream_body: None,
+                    body: Some("analysis task failed".to_string()),
+                });
+        }
+    };
+
+    match outcome {
         Ok(analysis) => HttpResponse::Ok()
             .content_type(ContentType::json())
             .json(analysis),

--- a/src/image_utils.rs
+++ b/src/image_utils.rs
@@ -136,6 +136,56 @@ fn angle(image: &DynamicImage, name: &str) -> f32 {
     (angle - 90.0).to_radians() as f32
 }
 
+/// Projection appliquée par [`rotate`] : rotation autour du centre, sur un canevas
+/// agrandi pour ne rien perdre. Exposée pour transporter une position connue — une ancre
+/// — dans l'image tournée sans la redétecter.
+pub fn rotation_projection(width: u32, height: u32, theta: f32) -> Projection {
+    let (width, height) = (width as f32, height as f32);
+    let (new_width, new_height) = (
+        (width * theta.cos().abs() + height * theta.sin().abs()),
+        (height * theta.cos().abs() + width * theta.sin().abs()),
+    );
+
+    let (cx, cy) = (width / 2f32, height / 2f32);
+    let (new_cx, new_cy) = ((new_width / 2f32), (new_height / 2f32));
+
+    Projection::translate(new_cx, new_cy)
+        * Projection::rotate(theta)
+        * Projection::translate(-cx, -cy)
+}
+
+/// Rectangle englobant d'un rectangle transporté par [`rotation_projection`].
+pub fn rotate_rect(
+    (x, y, w, h): (u32, u32, u32, u32),
+    width: u32,
+    height: u32,
+    theta: f32,
+) -> (u32, u32, u32, u32) {
+    let projection = rotation_projection(width, height, theta);
+    let corners = [
+        (x as f32, y as f32),
+        ((x + w) as f32, y as f32),
+        ((x + w) as f32, (y + h) as f32),
+        (x as f32, (y + h) as f32),
+    ];
+
+    let mapped: Vec<(f32, f32)> = corners
+        .iter()
+        .map(|&(px, py)| projection * (px, py))
+        .collect();
+    let min_x = mapped.iter().map(|p| p.0).fold(f32::MAX, f32::min).max(0.0);
+    let min_y = mapped.iter().map(|p| p.1).fold(f32::MAX, f32::min).max(0.0);
+    let max_x = mapped.iter().map(|p| p.0).fold(f32::MIN, f32::max);
+    let max_y = mapped.iter().map(|p| p.1).fold(f32::MIN, f32::max);
+
+    (
+        min_x as u32,
+        min_y as u32,
+        (max_x - min_x).max(1.0) as u32,
+        (max_y - min_y).max(1.0) as u32,
+    )
+}
+
 pub fn rotate(image: &DynamicImage, theta: f32) -> DynamicImage {
     let image = image.to_rgb8();
 
@@ -145,13 +195,8 @@ pub fn rotate(image: &DynamicImage, theta: f32) -> DynamicImage {
         (height * theta.cos().abs() + width * theta.sin().abs()),
     );
 
-    let (cx, cy) = (width / 2f32, height / 2f32);
-    let (new_cx, new_cy) = ((new_width / 2f32), (new_height / 2f32));
-
     let mut new_image = ImageBuffer::from_pixel(new_width as u32, new_height as u32, WHITE);
-    let projection = Projection::translate(new_cx, new_cy)
-        * Projection::rotate(theta)
-        * Projection::translate(-cx, -cy);
+    let projection = rotation_projection(image.width(), image.height(), theta);
 
     warp_into(
         &image,
@@ -244,4 +289,52 @@ pub fn save_image_in_debug(image: &DynamicImage, name: &str, suffix: &str) {
     image
         .save(debug_dir.join(format!("{}_{}.png", name, suffix)))
         .unwrap_or_else(|e| panic!("Failed to save image: {}, {}", name, e));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_rect_rotated_by_zero_is_itself() {
+        assert_eq!(
+            rotate_rect((10, 20, 30, 40), 200, 100, 0.0),
+            (10, 20, 30, 40)
+        );
+    }
+
+    /// Un quart de tour échange largeur et hauteur du rectangle, et le canevas s'élargit
+    /// pour tout contenir : le rectangle reste dans les bornes.
+    #[test]
+    fn a_quarter_turn_swaps_the_sides() {
+        let (_, _, w, h) = rotate_rect((10, 20, 30, 40), 200, 100, std::f32::consts::FRAC_PI_2);
+
+        assert!((w as i32 - 40).abs() <= 1, "w={}", w);
+        assert!((h as i32 - 30).abs() <= 1, "h={}", h);
+    }
+
+    /// Le rectangle transporté doit correspondre à l'image transportée : on vérifie que
+    /// le centre du rectangle tourné est le centre de l'original passé par la même
+    /// projection.
+    #[test]
+    fn the_transported_rect_follows_the_image() {
+        let theta = 0.3;
+        let (x, y, w, h) = rotate_rect((50, 60, 20, 10), 300, 200, theta);
+        let center = ((x + w / 2) as f32, (y + h / 2) as f32);
+
+        let expected = rotation_projection(300, 200, theta) * (60.0, 65.0);
+
+        assert!(
+            (center.0 - expected.0).abs() < 2.0,
+            "{:?} vs {:?}",
+            center,
+            expected
+        );
+        assert!(
+            (center.1 - expected.1).abs() < 2.0,
+            "{:?} vs {:?}",
+            center,
+            expected
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod http;
 pub mod image_utils;
 pub mod ocr;
 pub mod ocrs;
+pub mod provenance;
 pub mod rib;
 pub mod shapes;
 pub mod tesseract;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main() {
 
         let paths: Vec<&Path> = args[1..].iter().map(Path::new).collect();
         paths.iter().for_each(|path| {
-            let result = Analysis::try_from((*path, Some(Hint::Type(Type::Rib))));
+            let result = Analysis::try_from((*path, Some(Hint::Type(Type::Twoddoc))));
             match result {
                 Ok(analysis_result) => {
                     let json = json!({

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -164,7 +164,7 @@ fn zoom_and_extract_account_holder(
     let code_postal_word_regex = Regex::new(r"^\d{5}").unwrap();
 
     let postal_anchors = extract_anchors(
-        text_lines,
+        text_lines.clone(),
         &code_postal_word_regex,
         Some(&code_postal_line_regex),
     );
@@ -211,9 +211,10 @@ fn zoom_and_extract_account_holder(
         return account_holder;
     }
 
+    // Le mot « titulaire » se cherche dans les lignes déjà reconnues : relancer la
+    // reconnaissance de la page entière pour l'y trouver coûtait un appel complet.
     let account_holder_word_regex = Regex::new(r"(?i)titulaire").unwrap();
-    let (_, _text_lines, account_holder_anchors) =
-        ocrs_anchors(img, &account_holder_word_regex, None);
+    let account_holder_anchors = extract_anchors(text_lines, &account_holder_word_regex, None);
 
     account_holder_anchors
         .iter()

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -6,11 +6,11 @@ use ocrs::{TextItem, TextLine};
 use regex::Regex;
 
 use crate::{
-    image_utils::{clean_image, only_rotate, resize, rotate, save_image_in_debug},
+    image_utils::{clean_image, only_rotate, resize, rotate, rotate_rect, save_image_in_debug},
     ocrs::{extract_anchors, image_to_string_using_ocrs, ocrs_anchors},
     provenance::{AnchorSource, Engine, Provenance},
     rib::{extract_fr_bic, extract_iban, Rib},
-    shapes::Anchor,
+    shapes::{Anchor, Point},
     tesseract::{img_to_string_using_tesseract, tess_analyze},
     text::simple_account_holder::find_simple_account_holder,
 };
@@ -103,10 +103,30 @@ pub fn zoom_and_extract(
         provenance.angle_deg = Some(angle.to_degrees());
     }
 
+    // Après rotation, l'ancre était redétectée par une seconde analyse hocr de la page
+    // entière — quatre à cinq secondes pour une position qui se calcule : la rotation
+    // d'un rectangle est de la géométrie. La seconde analyse ne reste que lorsqu'il n'y
+    // avait pas d'ancre avant rotation, auquel cas elle cherche et ne redécouvre pas.
     let (img, maybe_anchor) = maybe_angle
         .map(|angle| {
             let rotated_img = rotate(img, angle);
-            let (_, _, new_anchor) = tess_analyze(&rotated_img);
+            let new_anchor = match &maybe_anchor {
+                Some(anchor) => {
+                    let (x, y, w, h) = rotate_rect(
+                        (
+                            anchor.top_left.x,
+                            anchor.top_left.y,
+                            anchor.width,
+                            anchor.height,
+                        ),
+                        img.width(),
+                        img.height(),
+                        angle,
+                    );
+                    Some(Anchor::new(Point::new(x, y), Point::new(x + w, y + h)))
+                }
+                None => tess_analyze(&rotated_img).2,
+            };
             (rotated_img, new_anchor)
         })
         .unwrap_or((img.clone(), maybe_anchor));

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -2,7 +2,7 @@ use std::io::Cursor;
 
 use image::{DynamicImage, ImageDecoder, ImageReader};
 use log::trace;
-use ocrs::TextLine;
+use ocrs::{TextItem, TextLine};
 use regex::Regex;
 
 use crate::{
@@ -10,6 +10,7 @@ use crate::{
     ocrs::{extract_anchors, image_to_string_using_ocrs, ocrs_anchors},
     provenance::{AnchorSource, Engine, Provenance},
     rib::{extract_fr_bic, extract_iban, Rib},
+    shapes::Anchor,
     tesseract::{img_to_string_using_tesseract, tess_analyze},
     text::simple_account_holder::find_simple_account_holder,
 };
@@ -155,6 +156,51 @@ fn find_civilite(s: &str) -> Option<usize> {
         .map(|m| m.start())
 }
 
+/// Texte des lignes déjà reconnues dont la boîte tombe dans le masque, dans l'ordre
+/// vertical, avec les mots de chaque ligne triés de gauche à droite.
+///
+/// Sert à trier les candidats avant de payer un recadrage : la page a été reconnue une
+/// fois, et son texte suffit à dire si un voisinage ressemble à une domiciliation ou à
+/// un titulaire. Il ne remplace pas le recadrage pour la lecture elle-même.
+fn text_in_mask(text_lines: &[TextLine], (x, y, w, h): (u32, u32, u32, u32)) -> String {
+    let (left, top, right, bottom) = (x as i32, y as i32, (x + w) as i32, (y + h) as i32);
+
+    let mut rows: Vec<(i32, String)> = text_lines
+        .iter()
+        .filter_map(|line| {
+            let mut words: Vec<(i32, String)> = line
+                .words()
+                .filter(|word| {
+                    let r = word.bounding_rect();
+                    let cx = (r.left() + r.right()) / 2;
+                    let cy = (r.top() + r.bottom()) / 2;
+                    cx >= left && cx < right && cy >= top && cy < bottom
+                })
+                .map(|word| (word.bounding_rect().left(), word.to_string()))
+                .collect();
+
+            if words.is_empty() {
+                return None;
+            }
+            words.sort_by_key(|(x, _)| *x);
+
+            let text = words
+                .into_iter()
+                .map(|(_, w)| w)
+                .collect::<Vec<String>>()
+                .join(" ");
+            Some((line.bounding_rect().top(), text))
+        })
+        .collect();
+
+    rows.sort_by_key(|(top, _)| *top);
+    rows.into_iter()
+        .map(|(_, t)| t)
+        .collect::<Vec<String>>()
+        .join("\n")
+}
+
+
 fn zoom_and_extract_account_holder(
     img: &DynamicImage,
     text_lines: Vec<TextLine>,
@@ -169,39 +215,83 @@ fn zoom_and_extract_account_holder(
         Some(&code_postal_line_regex),
     );
 
-    let account_holders = postal_anchors
+    // Un bloc adressé n'est pas forcément le titulaire : l'agence de domiciliation a
+    // elle aussi un code postal. Le chemin texte s'en protège en classant chaque bloc
+    // par son contexte ; ici, rien ne le faisait — et le recadrage aligné à droite,
+    // tenté faute de civilité, décale la fenêtre vers la gauche jusqu'à happer le nom du
+    // titulaire voisin, qui se retrouve collé à l'adresse de l'agence.
+    let domiciliation = Regex::new(r"(?i)(domiciliation|agence|cadre r[ée]serv[ée])").unwrap();
+    let holder_label = Regex::new(r"(?i)(titulaire|intitul[ée]|account owner)").unwrap();
+
+    // Le recadrage est un vrai zoom : sur les photos, la reconnaissance rapprochée lit
+    // les petits caractères que la passe pleine page rate. Lire le bloc dans les lignes
+    // de la page au lieu de recadrer a été mesuré — moins vingt points de titulaire.
+    let read_mask = |index: usize, mask: (u32, u32, u32, u32), suffix: &str| -> String {
+        let cropped_img = crop(img, mask, name, &format!("{}_{}", index, suffix));
+        image_to_string_using_ocrs(cropped_img)
+    };
+
+    // Chaque code postal détecté coûtait jusqu'à deux recadrages reconnus — jusqu'à
+    // douze appels ocrs sur un document dense en codes postaux (agence, mentions,
+    // cachet), pour un seul bloc utile. La lecture pleine page, déjà en main, permet de
+    // trier avant de payer : les codes postaux dont le voisinage se présente comme une
+    // domiciliation sont écartés d'emblée, ceux dont le voisinage porte une civilité ou
+    // un libellé de titulaire passent en premier, et l'examen s'arrête au premier bloc
+    // convaincant.
+    let mut ranked: Vec<(usize, &Anchor, i32)> = postal_anchors
         .iter()
         .enumerate()
         .map(|(index, anchor)| {
-            let cropped_img = crop(
-                img,
-                anchor.addr_mask(),
-                name,
-                &format!(r#"{}_addr_mask"#, index),
-            );
-            (index, image_to_string_using_ocrs(cropped_img), anchor)
-        })
-        .filter_map(|(index, text, anchor)| {
-            if match_civilite(&text) {
-                Some(text)
+            let around = text_in_mask(&text_lines, anchor.addr_mask());
+            let score = if holder_label.is_match(&around) {
+                2
+            } else if match_civilite(&around) {
+                1
+            } else if domiciliation.is_match(&around) {
+                -1
             } else {
-                let cropped_img = crop(
-                    img,
-                    anchor.right_align_addr_mask(),
-                    name,
-                    &format!(r#"{}_right_align_addr_mask"#, index),
-                );
-                let new_text = image_to_string_using_ocrs(cropped_img);
-
-                if match_civilite(&new_text) {
-                    Some(new_text)
-                } else {
-                    None
-                }
-            }
+                0
+            };
+            (index, anchor, score)
         })
-        .filter_map(|text| trim_holder(&text, &code_postal_line_regex))
-        .collect::<Vec<String>>();
+        .filter(|(_, _, score)| *score >= 0)
+        .collect();
+    ranked.sort_by_key(|(_, _, score)| -*score);
+
+    let mut account_holders: Vec<String> = Vec::new();
+    for (index, anchor, score) in ranked {
+        let text = read_mask(index, anchor.addr_mask(), "addr_mask");
+        // un bloc qui se présente comme domiciliation ne devient pas titulaire, même
+        // en le recadrant autrement
+        if domiciliation.is_match(&text) && !holder_label.is_match(&text) {
+            continue;
+        }
+        let text = if match_civilite(&text) {
+            Some(text)
+        } else {
+            let new_text = read_mask(
+                index,
+                anchor.right_align_addr_mask(),
+                "right_align_addr_mask",
+            );
+            if match_civilite(&new_text) && !domiciliation.is_match(&new_text) {
+                Some(new_text)
+            } else {
+                None
+            }
+        };
+        if let Some(holder) = text.and_then(|t| trim_holder(&t, &code_postal_line_regex)) {
+            let labelled = holder_label.is_match(&holder);
+            account_holders.push(holder);
+            // le premier bloc porteur d'un libellé — ou le premier tout court quand la
+            // page n'en désigne aucun — suffit : inutile de reconnaître les suivants
+            if labelled || score >= 1 {
+                break;
+            }
+        }
+    }
+    // à plusieurs candidats, celui qui porte un libellé de titulaire l'emporte
+    account_holders.sort_by_key(|text| !holder_label.is_match(text));
 
     // `s` porte déjà ses sauts de ligne : les recollecter caractère à caractère
     // aplatirait le titulaire en une seule ligne

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -63,7 +63,7 @@ pub fn zoom_and_extract(
 
         provenance.engine = Some(Engine::OcrsPage);
 
-        let bic = extract_fr_bic(&ocrs_text);
+        let bic = extract_fr_bic(&ocrs_text, Some(&iban));
         let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
 
         return Some(Rib::from_iban(iban, account_holder, bic));
@@ -78,7 +78,7 @@ pub fn zoom_and_extract(
             provenance.engine = Some(Engine::OcrsCrop);
 
             let account_holder = zoom_and_extract_account_holder(img, text_lines.clone(), name);
-            let bic = extract_fr_bic(&ocrs_text);
+            let bic = extract_fr_bic(&ocrs_text, Some(&iban));
 
             return Some(Rib::from_iban(iban, account_holder, bic));
         }
@@ -90,7 +90,7 @@ pub fn zoom_and_extract(
             provenance.engine = Some(Engine::OcrsNarrowCrop);
 
             let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
-            let bic = extract_fr_bic(&ocrs_text);
+            let bic = extract_fr_bic(&ocrs_text, Some(&iban));
 
             return Some(Rib::from_iban(iban, account_holder, bic));
         }
@@ -129,7 +129,7 @@ pub fn zoom_and_extract(
 
             let (ocrs_text, text_lines, _) = ocrs_anchors(&img, &iban_regex, None);
             let account_holder = zoom_and_extract_account_holder(&img, text_lines, name);
-            let bic = extract_fr_bic(&ocrs_text);
+            let bic = extract_fr_bic(&ocrs_text, Some(&iban));
 
             return Some(Rib::from_iban(iban, account_holder, bic));
         }

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -65,7 +65,8 @@ pub fn zoom_and_extract(
         provenance.engine = Some(Engine::OcrsPage);
 
         let bic = extract_fr_bic(&ocrs_text, Some(&iban));
-        let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
+        let account_holder =
+            zoom_and_extract_account_holder_traced(img, text_lines, name, provenance);
 
         return Some(Rib::from_iban(iban, account_holder, bic));
     };
@@ -78,7 +79,8 @@ pub fn zoom_and_extract(
         if let Some(iban) = extract_iban_in_image(&iban_image, name) {
             provenance.engine = Some(Engine::OcrsCrop);
 
-            let account_holder = zoom_and_extract_account_holder(img, text_lines.clone(), name);
+            let account_holder =
+                zoom_and_extract_account_holder_traced(img, text_lines.clone(), name, provenance);
             let bic = extract_fr_bic(&ocrs_text, Some(&iban));
 
             return Some(Rib::from_iban(iban, account_holder, bic));
@@ -90,7 +92,8 @@ pub fn zoom_and_extract(
         if let Some(iban) = extract_iban_in_image(&iban_image, name) {
             provenance.engine = Some(Engine::OcrsNarrowCrop);
 
-            let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
+            let account_holder =
+                zoom_and_extract_account_holder_traced(img, text_lines, name, provenance);
             let bic = extract_fr_bic(&ocrs_text, Some(&iban));
 
             return Some(Rib::from_iban(iban, account_holder, bic));
@@ -149,7 +152,8 @@ pub fn zoom_and_extract(
             provenance.engine = Some(Engine::TessCrop);
 
             let (ocrs_text, text_lines, _) = ocrs_anchors(&img, &iban_regex, None);
-            let account_holder = zoom_and_extract_account_holder(&img, text_lines, name);
+            let account_holder =
+                zoom_and_extract_account_holder_traced(&img, text_lines, name, provenance);
             let bic = extract_fr_bic(&ocrs_text, Some(&iban));
 
             return Some(Rib::from_iban(iban, account_holder, bic));
@@ -220,13 +224,16 @@ fn text_in_mask(text_lines: &[TextLine], (x, y, w, h): (u32, u32, u32, u32)) -> 
         .join("\n")
 }
 
-
-fn zoom_and_extract_account_holder(
+fn zoom_and_extract_account_holder_traced(
     img: &DynamicImage,
     text_lines: Vec<TextLine>,
     name: &str,
+    provenance: &mut Provenance,
 ) -> Option<String> {
-    let code_postal_line_regex = Regex::new(r"[[:space:]]*\d{5}\s+[[:alpha:]]").unwrap();
+    // Le code postal peut être collé à la ville — « 44800ST HERBLAIN » — selon le
+    // moteur et l'image ; l'espace n'est pas garanti. Le chemin texte le tolère déjà,
+    // le chemin image l'exigeait, et perdait alors toute ancre de titulaire.
+    let code_postal_line_regex = Regex::new(r"[[:space:]]*\d{5}\s*[[:alpha:]]").unwrap();
     let code_postal_word_regex = Regex::new(r"^\d{5}").unwrap();
 
     let postal_anchors = extract_anchors(
@@ -258,6 +265,8 @@ fn zoom_and_extract_account_holder(
     // domiciliation sont écartés d'emblée, ceux dont le voisinage porte une civilité ou
     // un libellé de titulaire passent en premier, et l'examen s'arrête au premier bloc
     // convaincant.
+    provenance.postal_anchors = postal_anchors.len() as u32;
+
     let mut ranked: Vec<(usize, &Anchor, i32)> = postal_anchors
         .iter()
         .enumerate()
@@ -277,9 +286,11 @@ fn zoom_and_extract_account_holder(
         .filter(|(_, _, score)| *score >= 0)
         .collect();
     ranked.sort_by_key(|(_, _, score)| -*score);
+    provenance.holder_candidates = ranked.len() as u32;
 
     let mut account_holders: Vec<String> = Vec::new();
     for (index, anchor, score) in ranked {
+        provenance.holder_blocks_read += 1;
         let text = read_mask(index, anchor.addr_mask(), "addr_mask");
         // un bloc qui se présente comme domiciliation ne devient pas titulaire, même
         // en le recadrant autrement

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 use crate::{
     image_utils::{clean_image, only_rotate, resize, rotate, save_image_in_debug},
     ocrs::{extract_anchors, image_to_string_using_ocrs, ocrs_anchors},
+    provenance::{AnchorSource, Engine, Provenance},
     rib::{extract_fr_bic, extract_iban, Rib},
     tesseract::{img_to_string_using_tesseract, tess_analyze},
     text::simple_account_holder::find_simple_account_holder,
@@ -16,26 +17,55 @@ use crate::{
 const OPTIMAL_TESSERACT_HEIGHT: u32 = 30;
 
 pub fn image_bytes_to_rib(content: Vec<u8>, name: &str) -> Option<Rib> {
-    let img = bytes_to_img(content)?;
-    save_image_in_debug(&img, name, "");
-
-    zoom_and_extract(&img, name).or_else(|| {
-        let cleaned_img = clean_image(&img, name);
-        zoom_and_extract(&cleaned_img, name)
-    })
+    image_bytes_to_rib_traced(content, name, &mut Provenance::default())
 }
 
-pub fn zoom_and_extract(img: &DynamicImage, name: &str) -> Option<Rib> {
-    let mut rib = None;
+/// Même traitement, en consignant au passage la stratégie qui a abouti.
+pub fn image_bytes_to_rib_traced(
+    content: Vec<u8>,
+    name: &str,
+    provenance: &mut Provenance,
+) -> Option<Rib> {
+    let img = bytes_to_img(content)?;
+
+    provenance.image_width = img.width();
+    provenance.image_height = img.height();
+
+    save_image_in_debug(&img, name, "");
+
+    if let Some(rib) = zoom_and_extract(&img, name, provenance) {
+        return Some(rib);
+    }
+
+    provenance.second_pass = true;
+
+    let cleaned_img = clean_image(&img, name);
+    zoom_and_extract(&cleaned_img, name, provenance)
+}
+
+pub fn zoom_and_extract(
+    img: &DynamicImage,
+    name: &str,
+    provenance: &mut Provenance,
+) -> Option<Rib> {
     let iban_regex = Regex::new(r"(?:^|\s)FR[\dO]").unwrap();
 
     let (ocrs_text, text_lines, maybe_anchors) = ocrs_anchors(img, &iban_regex, None);
     let maybe_anchor = maybe_anchors.first();
 
+    if let Some(anchor) = maybe_anchor {
+        provenance.anchor = Some(AnchorSource::Ocrs);
+        provenance.anchor_height = Some(anchor.height);
+    }
+
     if let Some(iban) = extract_iban(&ocrs_text) {
         trace!("early returns from ocrs for: {}", name);
+
+        provenance.engine = Some(Engine::OcrsPage);
+
         let bic = extract_fr_bic(&ocrs_text);
         let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
+
         return Some(Rib::from_iban(iban, account_holder, bic));
     };
 
@@ -43,30 +73,34 @@ pub fn zoom_and_extract(img: &DynamicImage, name: &str) -> Option<Rib> {
         trace!("ocrs anchor found");
 
         let iban_image = crop(img, anchor.iban_mask(), name, "mask");
-        let iban = extract_iban_in_image(&iban_image, name);
 
-        if let Some(iban) = iban {
+        if let Some(iban) = extract_iban_in_image(&iban_image, name) {
+            provenance.engine = Some(Engine::OcrsCrop);
+
             let account_holder = zoom_and_extract_account_holder(img, text_lines.clone(), name);
             let bic = extract_fr_bic(&ocrs_text);
-            rib = Some(Rib::from_iban(iban, account_holder, bic));
-        } else {
-            // maybe this is a long iban with some | between words
-            let iban_image = crop(img, anchor.narrow_iban_mask(), name, "narrow_mask");
-            let iban = extract_iban_in_image(&iban_image, name);
 
-            if let Some(iban) = iban {
-                let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
-                let bic = extract_fr_bic(&ocrs_text);
-                rib = Some(Rib::from_iban(iban, account_holder, bic));
-            }
+            return Some(Rib::from_iban(iban, account_holder, bic));
+        }
+
+        // maybe this is a long iban with some | between words
+        let iban_image = crop(img, anchor.narrow_iban_mask(), name, "narrow_mask");
+
+        if let Some(iban) = extract_iban_in_image(&iban_image, name) {
+            provenance.engine = Some(Engine::OcrsNarrowCrop);
+
+            let account_holder = zoom_and_extract_account_holder(img, text_lines, name);
+            let bic = extract_fr_bic(&ocrs_text);
+
+            return Some(Rib::from_iban(iban, account_holder, bic));
         }
     }
 
-    if rib.is_some() {
-        return rib;
-    }
-
     let (_hocr_string, maybe_angle, maybe_anchor) = tess_analyze(img);
+
+    if let Some(angle) = maybe_angle {
+        provenance.angle_deg = Some(angle.to_degrees());
+    }
 
     let (img, maybe_anchor) = maybe_angle
         .map(|angle| {
@@ -79,22 +113,46 @@ pub fn zoom_and_extract(img: &DynamicImage, name: &str) -> Option<Rib> {
     if let Some(anchor) = maybe_anchor {
         trace!("tess anchor found");
 
+        if provenance.anchor.is_none() {
+            provenance.anchor = Some(AnchorSource::Tesseract);
+            provenance.anchor_height = Some(anchor.height);
+        }
+
         let iban_image = crop(&img, anchor.iban_mask(), name, "mask");
 
         let iban_image = only_rotate(&iban_image, name);
         let iban_image = resize(&iban_image, anchor.height, OPTIMAL_TESSERACT_HEIGHT);
         save_image_in_debug(&iban_image, name, "rotated_resized_mask");
 
-        let iban = extract_iban_in_image(&iban_image, name);
-        if let Some(iban) = iban {
+        if let Some(iban) = extract_iban_in_image(&iban_image, name) {
+            provenance.engine = Some(Engine::TessCrop);
+
             let (ocrs_text, text_lines, _) = ocrs_anchors(&img, &iban_regex, None);
             let account_holder = zoom_and_extract_account_holder(&img, text_lines, name);
             let bic = extract_fr_bic(&ocrs_text);
-            rib = Some(Rib::from_iban(iban, account_holder, bic));
+
+            return Some(Rib::from_iban(iban, account_holder, bic));
         }
     }
 
-    rib
+    None
+}
+
+fn match_civilite(s: &str) -> bool {
+    find_civilite(s).is_some()
+}
+
+fn find_civilite(s: &str) -> Option<usize> {
+    let civilite =
+        Regex::new(r"(?i)(^|\s)(m|monsieur|mr|mademoiselle|ml|mle|mlle|melle|madame|mme)\.?\s")
+            .unwrap();
+    let prenom_nom_ou =
+        Regex::new(r"[[:upper:]]+ +[[:upper:]]+ +OU +[[:upper:]]+ +[[:upper:]]+").unwrap();
+
+    civilite
+        .find(s)
+        .or_else(|| prenom_nom_ou.find(s))
+        .map(|m| m.start())
 }
 
 fn zoom_and_extract_account_holder(
@@ -104,31 +162,6 @@ fn zoom_and_extract_account_holder(
 ) -> Option<String> {
     let code_postal_line_regex = Regex::new(r"[[:space:]]*\d{5}\s+[[:alpha:]]").unwrap();
     let code_postal_word_regex = Regex::new(r"^\d{5}").unwrap();
-
-    fn match_civilite(s: &str) -> bool {
-        let civilite =
-            Regex::new(r"(?i)(^|\s)(m|monsieur|mr|mademoiselle|ml|mle|mlle|melle|madame|mme)\.?\s")
-                .unwrap();
-        let prenom_nom_ou =
-            Regex::new(r"[[:upper:]]+ +[[:upper:]]+ +OU +[[:upper:]]+ +[[:upper:]]+").unwrap();
-
-        civilite.is_match(s) || prenom_nom_ou.is_match(s)
-    }
-
-    fn find_civilite(s: &str) -> Option<usize> {
-        let civilite =
-            Regex::new(r"(?i)(^|\s)(m|monsieur|mr|mademoiselle|ml|mle|mlle|melle|madame|mme)\.?\s")
-                .unwrap();
-        let prenom_nom_ou =
-            Regex::new(r"[[:upper:]]+ +[[:upper:]]+ +OU +[[:upper:]]+ +[[:upper:]]+").unwrap();
-        if civilite.is_match(s) {
-            civilite.find(s).map(|m| m.start())
-        } else if prenom_nom_ou.is_match(s) {
-            prenom_nom_ou.find(s).map(|m| m.start())
-        } else {
-            None
-        }
-    }
 
     let postal_anchors = extract_anchors(
         text_lines,
@@ -167,24 +200,12 @@ fn zoom_and_extract_account_holder(
                 }
             }
         })
-        .map(|text| {
-            // on supprime tout ce qui se situe avant civilite
-            let start = find_civilite(&text).unwrap();
-            let text = text[start..].trim().to_string();
-
-            // on supprime toutes les lignes situées après le code postal
-            let lines: Vec<&str> = text.lines().collect();
-            let code_postal_index = lines
-                .iter()
-                .position(|line| code_postal_line_regex.is_match(line))
-                .unwrap();
-            lines[..code_postal_index + 1].join("\n")
-        })
+        .filter_map(|text| trim_holder(&text, &code_postal_line_regex))
         .collect::<Vec<String>>();
 
-    let account_holder = account_holders
-        .first()
-        .map(|s| s.lines().map(|l| l.to_string()).collect());
+    // `s` porte déjà ses sauts de ligne : les recollecter caractère à caractère
+    // aplatirait le titulaire en une seule ligne
+    let account_holder = account_holders.first().cloned();
 
     if account_holder.is_some() {
         return account_holder;
@@ -208,6 +229,26 @@ fn zoom_and_extract_account_holder(
         })
         .filter(|text| account_holder_word_regex.is_match(text))
         .find_map(|text| find_simple_account_holder(&text, 1))
+}
+
+/// Restreint un bloc reconnu au titulaire : on écarte ce qui précède la civilité, et ce
+/// qui suit le code postal.
+///
+/// Le code postal peut manquer alors qu'une civilité est présente — le recadrage aligné à
+/// droite décale la fenêtre et peut le laisser hors champ, et l'OCR ne le restitue pas
+/// toujours sous une forme reconnaissable. Dans ce cas on conserve le bloc, borné par la
+/// hauteur du recadrage, plutôt que d'abandonner.
+fn trim_holder(text: &str, postal_code: &Regex) -> Option<String> {
+    let start = find_civilite(text)?;
+    let text = text[start..].trim();
+
+    let lines: Vec<&str> = text.lines().collect();
+    let end = lines
+        .iter()
+        .position(|line| postal_code.is_match(line))
+        .map_or(lines.len(), |index| index + 1);
+
+    Some(lines[..end].join("\n"))
 }
 
 fn crop(
@@ -253,4 +294,56 @@ fn extract_iban_in_image(cropped_img: &DynamicImage, name: &str) -> Option<Strin
     );
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn postal_code() -> Regex {
+        Regex::new(r"[[:space:]]*\d{5}\s+[[:alpha:]]").unwrap()
+    }
+
+    #[test]
+    fn holder_is_trimmed_around_civility_and_postal_code() {
+        let text =
+            "Titulaire du compte\nM MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES\nDomiciliation";
+
+        assert_eq!(
+            trim_holder(text, &postal_code()).as_deref(),
+            Some("M MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES")
+        );
+    }
+
+    /// Un bloc sans code postal reconnaissable ne doit pas faire tomber l'analyse : le
+    /// recadrage aligné à droite peut le laisser hors champ, et l'OCR ne le restitue pas
+    /// toujours espacé comme attendu.
+    #[test]
+    fn a_holder_without_postal_code_is_kept_whole() {
+        assert_eq!(
+            trim_holder("M MATISSE HENRI\n51 RUE BERNARD ROY", &postal_code()).as_deref(),
+            Some("M MATISSE HENRI\n51 RUE BERNARD ROY")
+        );
+
+        // code postal collé à la ville : le motif ne le reconnaît pas
+        assert_eq!(
+            trim_holder("MME KAHLO FRIDA\n44100NANTES", &postal_code()).as_deref(),
+            Some("MME KAHLO FRIDA\n44100NANTES")
+        );
+    }
+
+    #[test]
+    fn a_block_without_civility_is_discarded() {
+        assert_eq!(
+            trim_holder("51 RUE BERNARD ROY\n44100 NANTES", &postal_code()),
+            None
+        );
+    }
+
+    #[test]
+    fn couples_without_civility_are_recognised() {
+        assert!(match_civilite("HENRI MATISSE OU FRIDA KAHLO"));
+        assert!(match_civilite("Madame Kahlo Frida"));
+        assert!(!match_civilite("51 RUE BERNARD ROY"));
+    }
 }

--- a/src/ocrs.rs
+++ b/src/ocrs.rs
@@ -110,7 +110,32 @@ pub fn extract_anchors(
                 .corners()
                 .map(|point| [point.x.round() as u32, point.y.round() as u32]);
 
-            Anchor::new(Point::new(p3[0], p3[1]), Point::new(p1[0], p1[1]))
+            // Les masques sont des multiples de la largeur de l'ancre. Pour un code
+            // postal collé à sa ville — « 44800ST » — la largeur du mot entier ferait un
+            // masque soixante pour cent trop large, qui empiète sur la colonne voisine :
+            // on ne garde que la largeur du motif reconnu. Mais seulement quand le motif
+            // est ancré en début de mot et bien plus court que lui : l'ancre d'IBAN
+            // « FR76 » suivie du reste doit rester le mot entier, sans quoi le recadrage
+            // étroit de l'IBAN devient minuscule et le rate.
+            let text = word.to_string();
+            let matched = word_regex
+                .find(&text)
+                .filter(|m| m.start() == 0)
+                .map(|m| m.end())
+                .unwrap_or(0);
+            let total = text.chars().count().max(1);
+            let width = p1[0].saturating_sub(p3[0]);
+            let is_postal = matched == 5 && text.chars().take(5).all(|c| c.is_ascii_digit());
+            let matched_width = if is_postal && matched < total {
+                (width as f32 * matched as f32 / total as f32).round() as u32
+            } else {
+                width
+            };
+
+            Anchor::new(
+                Point::new(p3[0], p3[1]),
+                Point::new(p3[0] + matched_width.max(1), p1[1]),
+            )
         })
         .collect::<Vec<Anchor>>()
 }

--- a/src/ocrs.rs
+++ b/src/ocrs.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use image::DynamicImage;
 use ocrs::{ImageSource, OcrEngine, OcrEngineParams, TextItem, TextLine};
 use regex::Regex;
@@ -8,24 +10,36 @@ use crate::shapes::{Anchor, Point};
 const DETECTION_MODEL: &[u8] = include_bytes!("../models/text-detection.rten");
 const RECOGNITION_MODEL: &[u8] = include_bytes!("../models/text-recognition.rten");
 
-pub fn image_to_string_using_ocrs(img: DynamicImage) -> String {
-    let img = img.into_rgb8();
+/// Moteur partagé.
+///
+/// Il était auparavant reconstruit à chaque appel, modèles rechargés compris, alors
+/// qu'un même document en déclenche plusieurs — un par recadrage d'adresse, et un par
+/// orientation essayée.
+static ENGINE: OnceLock<OcrEngine> = OnceLock::new();
 
-    #[allow(clippy::const_is_empty)]
-    if DETECTION_MODEL.is_empty() || RECOGNITION_MODEL.is_empty() {
-        panic!("--> ocrs models are empty in models/ directory. Please run `download_models.sh` to download the models.");
-    }
+fn engine() -> &'static OcrEngine {
+    ENGINE.get_or_init(|| {
+        #[allow(clippy::const_is_empty)]
+        if DETECTION_MODEL.is_empty() || RECOGNITION_MODEL.is_empty() {
+            panic!("--> ocrs models are empty in models/ directory. Please run `download_models.sh` to download the models.");
+        }
 
-    // 10 ms to load the models
-    let detection_model = Model::load_static_slice(DETECTION_MODEL).unwrap();
-    let recognition_model = Model::load_static_slice(RECOGNITION_MODEL).unwrap();
+        let detection_model = Model::load_static_slice(DETECTION_MODEL).unwrap();
+        let recognition_model = Model::load_static_slice(RECOGNITION_MODEL).unwrap();
 
-    let engine = OcrEngine::new(OcrEngineParams {
-        detection_model: Some(detection_model),
-        recognition_model: Some(recognition_model),
-        ..Default::default()
+        OcrEngine::new(OcrEngineParams {
+            detection_model: Some(detection_model),
+            recognition_model: Some(recognition_model),
+            ..Default::default()
+        })
+        .unwrap()
     })
-    .unwrap();
+}
+
+/// Détecte les mots, les groupe en lignes et les reconnaît.
+pub fn recognize(img: &DynamicImage) -> Vec<TextLine> {
+    let img = img.clone().into_rgb8();
+    let engine = engine();
 
     // Apply standard image pre-processing expected by this library (convert
     // to greyscale, map range to [-0.5, 0.5]).
@@ -39,12 +53,18 @@ pub fn image_to_string_using_ocrs(img: DynamicImage) -> String {
     // bounding boxes.
     let line_rects = engine.find_text_lines(&ocr_input, &word_rects);
 
-    // Recognize the characters in each line.
-    let line_texts = engine.recognize_text(&ocr_input, &line_rects).unwrap();
-
-    line_texts
+    engine
+        .recognize_text(&ocr_input, &line_rects)
+        .unwrap()
         .iter()
         .flatten()
+        .cloned()
+        .collect()
+}
+
+fn lines_to_text(text_lines: &[TextLine]) -> String {
+    text_lines
+        .iter()
         // Filter likely spurious detections. With future model improvements
         // this should become unnecessary.
         .filter(|l| l.to_string().len() > 1)
@@ -53,64 +73,20 @@ pub fn image_to_string_using_ocrs(img: DynamicImage) -> String {
         .join("\n")
 }
 
+pub fn image_to_string_using_ocrs(img: DynamicImage) -> String {
+    lines_to_text(&recognize(&img))
+}
+
 pub fn ocrs_anchors(
     img: &DynamicImage,
     word_regex: &Regex,
     line_regex: Option<&Regex>,
 ) -> (String, Vec<TextLine>, Vec<Anchor>) {
-    let img = img.clone().into_rgb8();
+    let text_lines = recognize(img);
+    let text = lines_to_text(&text_lines);
+    let anchors = extract_anchors(text_lines.clone(), word_regex, line_regex);
 
-    #[allow(clippy::const_is_empty)]
-    if DETECTION_MODEL.is_empty() || RECOGNITION_MODEL.is_empty() {
-        panic!("--> ocrs models are empty in models/ directory. Please run `download_models.sh` to download the models.");
-    }
-
-    // 10 ms to load the models
-    let detection_model = Model::load_static_slice(DETECTION_MODEL).unwrap();
-    let recognition_model = Model::load_static_slice(RECOGNITION_MODEL).unwrap();
-
-    let engine = OcrEngine::new(OcrEngineParams {
-        detection_model: Some(detection_model),
-        recognition_model: Some(recognition_model),
-        ..Default::default()
-    })
-    .unwrap();
-
-    // Apply standard image pre-processing expected by this library (convert
-    // to greyscale, map range to [-0.5, 0.5]).
-    let img_source = ImageSource::from_bytes(img.as_raw(), img.dimensions()).unwrap();
-    let ocr_input = engine.prepare_input(img_source).unwrap();
-
-    // Get oriented bounding boxes of text words in input image.
-    let word_rects = engine.detect_words(&ocr_input).unwrap();
-
-    // Group words into lines. Each line is represented by a list of word
-    // bounding boxes.
-    let line_rects = engine.find_text_lines(&ocr_input, &word_rects);
-
-    // Recognize the characters in each line.
-    let text_lines = engine
-        .recognize_text(&ocr_input, &line_rects)
-        .unwrap()
-        .iter()
-        .flatten()
-        .cloned()
-        .collect::<Vec<TextLine>>();
-
-    let text = text_lines
-        .iter()
-        // Filter likely spurious detections. With future model improvements
-        // this should become unnecessary.
-        .filter(|l| l.to_string().len() > 1)
-        .map(|l| l.to_string())
-        .collect::<Vec<String>>()
-        .join("\n");
-
-    (
-        text,
-        text_lines.clone(),
-        extract_anchors(text_lines, word_regex, line_regex),
-    )
+    (text, text_lines, anchors)
 }
 
 pub fn extract_anchors(

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -1,0 +1,100 @@
+//! Trace du chemin suivi pour extraire un RIB.
+//!
+//! Le pipeline enchaîne plusieurs stratégies jusqu'à ce que l'une aboutisse, sans
+//! jamais dire laquelle. Sans cette trace, impossible de savoir quelles branches
+//! servent réellement, donc lesquelles méritent d'être améliorées ou retirées.
+//!
+//! Ne contient que des étiquettes et des grandeurs géométriques : aucun texte reconnu,
+//! de sorte qu'une trace puisse être publiée sans divulguer le contenu du document.
+
+/// Branche d'aiguillage retenue par `analysis::vec_to_rib`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Route {
+    /// Texte extrait du PDF, sans OCR.
+    PdfText,
+    /// PDF rasterisé faute de texte exploitable.
+    PdfImage,
+    /// Image fournie telle quelle.
+    Image,
+    /// Fichier texte brut.
+    PlainText,
+}
+
+/// Moteur ayant fourni l'ancre de localisation de l'IBAN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AnchorSource {
+    Ocrs,
+    Tesseract,
+}
+
+/// Stratégie ayant effectivement produit l'IBAN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Engine {
+    /// `pdftotext`, sans OCR.
+    PdfText,
+    /// OCR de la page entière par ocrs.
+    OcrsPage,
+    /// Recadrage autour d'une ancre ocrs.
+    OcrsCrop,
+    /// Recadrage étroit, pour les IBAN espacés de façon inhabituelle.
+    OcrsNarrowCrop,
+    /// Recadrage autour d'une ancre tesseract, après redressement éventuel.
+    TessCrop,
+}
+
+impl Route {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Route::PdfText => "pdf_text",
+            Route::PdfImage => "pdf_image",
+            Route::Image => "image",
+            Route::PlainText => "plain_text",
+        }
+    }
+}
+
+impl AnchorSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AnchorSource::Ocrs => "ocrs",
+            AnchorSource::Tesseract => "tess",
+        }
+    }
+}
+
+impl Engine {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Engine::PdfText => "pdf_text",
+            Engine::OcrsPage => "ocrs:page",
+            Engine::OcrsCrop => "ocrs:crop",
+            Engine::OcrsNarrowCrop => "ocrs:narrow",
+            Engine::TessCrop => "tess:crop",
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Provenance {
+    pub route: Option<Route>,
+    pub anchor: Option<AnchorSource>,
+    /// Hauteur de l'ancre en pixels : c'est la grandeur qui décide si le texte est
+    /// assez grand pour être reconnu.
+    pub anchor_height: Option<u32>,
+    /// Inclinaison détectée par tesseract, en degrés.
+    pub angle_deg: Option<f32>,
+    pub engine: Option<Engine>,
+    /// Vrai si le résultat vient de la seconde passe, sur image nettoyée.
+    pub second_pass: bool,
+    pub image_width: u32,
+    pub image_height: u32,
+}
+
+impl Provenance {
+    pub fn route(route: Route) -> Self {
+        Provenance {
+            route: Some(route),
+            ..Default::default()
+        }
+    }
+}

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -88,6 +88,11 @@ pub struct Provenance {
     pub second_pass: bool,
     pub image_width: u32,
     pub image_height: u32,
+    /// Codes postaux détectés sur la page, candidats retenus après tri, blocs lus.
+    /// Trois comptes qui disent où la recherche du titulaire s'arrête.
+    pub postal_anchors: u32,
+    pub holder_candidates: u32,
+    pub holder_blocks_read: u32,
 }
 
 impl Provenance {

--- a/src/rib.rs
+++ b/src/rib.rs
@@ -47,6 +47,111 @@ impl Rib {
             None
         }
     }
+
+    pub fn iban(&self) -> &str {
+        &self.iban
+    }
+
+    pub fn bic(&self) -> Option<&str> {
+        self.bic.as_deref()
+    }
+
+    pub fn account_holder(&self) -> Option<&str> {
+        self.account_holder.as_deref()
+    }
+
+    pub fn bank_name(&self) -> Option<&str> {
+        self.bank_name.as_deref()
+    }
+}
+
+/// Normalise un IBAN : séparateurs retirés, majuscules.
+pub fn normalize_iban(iban: &str) -> String {
+    iban.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_uppercase())
+        .collect()
+}
+
+/// Valeur d'un caractère de numéro de compte pour le calcul de la clé RIB.
+/// A,J→1 · B,K,S→2 · C,L,T→3 · D,M,U→4 · E,N,V→5 · F,O,W→6 · G,P,X→7 · H,Q,Y→8 · I,R,Z→9
+/// Noter que la troisième série démarre à 2 : aucune lettre de S à Z ne vaut 1.
+fn account_char_value(c: char) -> Option<u64> {
+    match c {
+        '0'..='9' => Some(c as u64 - '0' as u64),
+        'A'..='I' => Some(c as u64 - 'A' as u64 + 1),
+        'J'..='R' => Some(c as u64 - 'J' as u64 + 1),
+        'S'..='Z' => Some(c as u64 - 'S' as u64 + 2),
+        _ => None,
+    }
+}
+
+/// Clé RIB française : 97 - (89·banque + 15·guichet + 3·compte) mod 97.
+pub fn rib_key(bank: &str, branch: &str, account: &str) -> Option<u8> {
+    fn to_number(s: &str) -> Option<u64> {
+        s.chars().try_fold(0u64, |acc, c| {
+            account_char_value(c).map(|v| (acc * 10 + v) % 97)
+        })
+    }
+
+    let rest = (89 * to_number(bank)? + 15 * to_number(branch)? + 3 * to_number(account)?) % 97;
+
+    Some((97 - rest) as u8)
+}
+
+/// Découpe un IBAN français en (banque, guichet, compte, clé RIB).
+fn split_fr_iban(iban: &str) -> Option<(String, String, String, String)> {
+    let normalized = normalize_iban(iban);
+
+    if normalized.len() != 27 || !normalized.starts_with("FR") {
+        return None;
+    }
+
+    let c: Vec<char> = normalized.chars().collect();
+
+    Some((
+        c[4..9].iter().collect(),
+        c[9..14].iter().collect(),
+        c[14..25].iter().collect(),
+        c[25..27].iter().collect(),
+    ))
+}
+
+/// Vérifie la clé RIB (positions 25-26) d'un IBAN français.
+///
+/// Contrôle indépendant du mod-97 de l'IBAN : les deux combinés font tomber le taux de
+/// faux positifs de 1/97 à ~1/9400 quand on teste des candidats issus de l'OCR.
+pub fn check_rib_key(iban: &str) -> bool {
+    let Some((bank, branch, account, key)) = split_fr_iban(iban) else {
+        return false;
+    };
+
+    match (rib_key(&bank, &branch, &account), key.parse::<u8>()) {
+        (Some(expected), Ok(found)) => expected == found,
+        _ => false,
+    }
+}
+
+/// Reconstruit un IBAN FR à partir d'un BBAN de 23 caractères, en calculant la clé de
+/// contrôle IBAN. Permet de retrouver l'IBAN depuis le seul tableau RIB.
+pub fn iban_from_bban(bban: &str) -> Option<String> {
+    let bban = normalize_iban(bban);
+
+    if bban.len() != 23 {
+        return None;
+    }
+
+    // "FR00" déplacé en fin de chaîne, lettres converties (A=10 … Z=35).
+    let rest = bban
+        .chars()
+        .chain("FR00".chars())
+        .try_fold(0u64, |acc, c| match c {
+            '0'..='9' => Some((acc * 10 + (c as u64 - '0' as u64)) % 97),
+            'A'..='Z' => Some((acc * 100 + (c as u64 - 'A' as u64 + 10)) % 97),
+            _ => None,
+        })?;
+
+    Some(format!("FR{:02}{}", 98 - rest, bban))
 }
 
 pub fn replace_char_by_digit_in_2_and_3_position(ibans: Vec<String>) -> Vec<String> {
@@ -243,6 +348,48 @@ mod tests {
         ";
 
         assert_eq!(extract_iban(iban_with_faults).unwrap(), iban);
+    }
+
+    #[test]
+    fn test_rib_key() {
+        // IBAN de démonstration de la Banque de France, découpé en ses composants.
+        assert_eq!(rib_key("30001", "00064", "49190095620"), Some(88));
+
+        // les lettres du numéro de compte passent par la table de conversion
+        assert_eq!(rib_key("30001", "00064", "4919009562A"), Some(85));
+
+        // un caractère hors alphanumérique invalide le calcul
+        assert_eq!(rib_key("30001", "00064", "4919009562-"), None);
+    }
+
+    #[test]
+    fn test_check_rib_key() {
+        assert!(check_rib_key(IBAN));
+        assert!(check_rib_key("FR7630001000644919009562088"));
+
+        // clé RIB altérée
+        assert!(!check_rib_key("FR7630001000644919009562087"));
+
+        // IBAN non français, ou de longueur inattendue
+        assert!(!check_rib_key("DE89370400440532013000"));
+        assert!(!check_rib_key("FR76 3000"));
+    }
+
+    #[test]
+    fn test_iban_from_bban() {
+        // le tableau RIB seul suffit à reconstituer l'IBAN
+        assert_eq!(
+            iban_from_bban("30001000644919009562088").as_deref(),
+            Some("FR7630001000644919009562088")
+        );
+
+        assert_eq!(iban_from_bban("trop court"), None);
+    }
+
+    #[test]
+    fn test_normalize_iban() {
+        assert_eq!(normalize_iban(IBAN), "FR7630001000644919009562088");
+        assert_eq!(normalize_iban("fr76|3000 1000"), "FR7630001000");
     }
 
     fn to_rib(path: &str) -> Rib {

--- a/src/rib.rs
+++ b/src/rib.rs
@@ -32,20 +32,10 @@ impl Rib {
             .map(|addr| addr.lines().join("\n"))
             .or_else(|| find_simple_account_holder(&text, 3));
 
-        let bic = extract_fr_bic(&text);
+        let iban = extract_iban(&text)?;
+        let bic = extract_fr_bic(&text, Some(&iban));
 
-        if let Some(iban) = extract_iban(&text) {
-            let bank_name = IbanToBankName::new().bank_name(&iban);
-
-            Some(Rib {
-                account_holder,
-                iban,
-                bic,
-                bank_name,
-            })
-        } else {
-            None
-        }
+        Some(Rib::from_iban(iban, account_holder, bic))
     }
 
     pub fn iban(&self) -> &str {
@@ -273,19 +263,34 @@ pub fn extract_iban(text: &str) -> Option<String> {
     }
 }
 
-pub fn extract_fr_bic(content: &str) -> Option<String> {
+/// Écarte les candidats qui ne sont qu'un fragment de l'IBAN voisin.
+///
+/// Le motif `[A-Z]{4}FR[A-Z0-9]{2}` capture quatre lettres quelconques suivies du début
+/// de l'IBAN : « NBICFR67190 » sur un IBAN commençant par FR67190. Le libellé collé à sa
+/// valeur suffit à le produire, et la passe sans espaces le provoque systématiquement.
+///
+/// Le candidat était alors soit retourné tel quel quand le vrai BIC avait été mal lu,
+/// soit rejeté avec lui pour cause d'ambiguïté. Ce qui suit le code établissement doit
+/// être un code pays, pas la suite d'un numéro de compte.
+fn is_iban_fragment(candidate: &str, iban: &str) -> bool {
+    let candidate = normalize_iban(candidate);
+
+    candidate.len() > 4 && normalize_iban(iban).starts_with(&candidate[4..])
+}
+
+/// `iban`, lorsqu'il est connu, sert à écarter les faux candidats qu'il engendre.
+pub fn extract_fr_bic(content: &str, iban: Option<&str>) -> Option<String> {
     let fr_without_space = Regex::new(r"[A-Z]{4}FR[A-Z0-9]{2}([A-Z0-9]{3})?").unwrap();
     let fr_with_xxx_with_space = Regex::new(r"[A-Z]{4}\s?FR\s?[A-Z0-9]{2}\s?XXX?").unwrap();
 
-    // Helper to get unique matches
-    fn get_unique_matches(regex: &Regex, text: &str) -> Vec<String> {
-        let matches: Vec<String> = regex
+    let get_unique_matches = |regex: &Regex, text: &str| -> Vec<String> {
+        regex
             .find_iter(text)
             .map(|m| m.as_str().to_string())
+            .filter(|candidate| !iban.is_some_and(|iban| is_iban_fragment(candidate, iban)))
             .unique()
-            .collect();
-        matches.into_iter().collect()
-    }
+            .collect()
+    };
 
     let mut fr_without_space_matches = get_unique_matches(&fr_without_space, content);
     log::trace!("fr_without_space_matches: {:?}", fr_without_space_matches);
@@ -384,6 +389,50 @@ mod tests {
         );
 
         assert_eq!(iban_from_bban("trop court"), None);
+    }
+
+    /// Le motif du BIC attrape quatre lettres quelconques suivies du début de l'IBAN.
+    /// Connaître l'IBAN suffit à les distinguer d'un vrai code établissement.
+    #[test]
+    fn iban_fragments_are_not_mistaken_for_a_bic() {
+        let iban = "FR6719069478526623075402Z93";
+
+        // observés sur corpus : le libellé collé à sa valeur produit ces candidats
+        assert!(is_iban_fragment("NBICFR67190", iban));
+        assert!(is_iban_fragment("DGARFR67190", iban));
+
+        // un vrai BIC ne prolonge pas l'IBAN
+        assert!(!is_iban_fragment("PSSTFRPPNTE", iban));
+        assert!(!is_iban_fragment("CMCIFR2A", iban));
+        assert!(!is_iban_fragment("SOGEFRPP", iban));
+    }
+
+    #[test]
+    fn bic_is_extracted_despite_a_glued_label() {
+        let iban = "FR6719069478526623075402Z93";
+
+        // le vrai BIC coexiste avec le faux candidat : renoncer serait perdre les deux
+        let text = "IBANFR6719069478526623075402Z93 BIC PSSTFRPPNTE";
+        assert_eq!(
+            extract_fr_bic(text, Some(iban)).as_deref(),
+            Some("PSSTFRPPNTE")
+        );
+
+        // le vrai BIC est illisible : mieux vaut ne rien rendre qu'un fragment d'IBAN
+        let text = "IBANFR6719069478526623075402Z93 BIC PS5TFRPP";
+        assert_eq!(extract_fr_bic(text, Some(iban)), None);
+    }
+
+    #[test]
+    fn bic_extraction_still_works_without_an_iban() {
+        assert_eq!(
+            extract_fr_bic("BIC AGRIFRPP847", None).as_deref(),
+            Some("AGRIFRPP847")
+        );
+        assert_eq!(
+            extract_fr_bic("BIC BOUS FRPP XXX", None).as_deref(),
+            Some("BOUS FRPP XXX")
+        );
     }
 
     #[test]

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -135,7 +135,7 @@ fn find_angle(hocr_string: &str, iban_anchor: ElementRef) -> Option<f32> {
     angle
 }
 
-fn iban_el(doc: &Html) -> Option<ElementRef> {
+fn iban_el(doc: &Html) -> Option<ElementRef<'_>> {
     let selector = Selector::parse("span.ocrx_word").unwrap();
     let re_iban = Regex::new(r"(?:^|\s)FR[\dO]").unwrap();
 

--- a/src/text/address.rs
+++ b/src/text/address.rs
@@ -15,13 +15,42 @@ pub struct Addr {
     pub addr_type: AddrType,
 }
 
+/// Une raison sociale peut précéder la civilité et fait partie du titulaire.
+fn is_legal_form(line: &str) -> bool {
+    Regex::new(r"(?i)^\s*(SCI|SAS|SASU|SARL|EURL|SA|SNC|SC|ASSOCIATION|ASS|GIE|SEL|SELARL|EARL|GAEC|SCP|SCM|SCEA)\b")
+        .unwrap()
+        .is_match(line)
+}
+
+fn civility_index(lines: &[String]) -> Option<usize> {
+    let civility =
+        Regex::new(r"(?i)(^|\s)(m|monsieur|mr|mademoiselle|ml|mle|mlle|melle|madame|mme)\.?\s")
+            .unwrap();
+
+    lines.iter().position(|line| civility.is_match(line))
+}
+
 impl Addr {
     pub fn lines(&self) -> Vec<String> {
         let header = Regex::new(r"(?i)(titulaire|intitulé|identit[e|é] bancaire)").unwrap();
         let intitule = Regex::new(r"(?i)(intitulé du compte)").unwrap();
 
-        self.inner_lines
-            .clone()
+        // Le bloc est remonté depuis le code postal jusqu'à un mot-clé ou six lignes.
+        // Sans mot-clé, il avale ce qui précède dans la même colonne : référence
+        // client, date d'édition, nom d'agence. La civilité marque le début réel du
+        // titulaire ; seule une raison sociale placée juste au-dessus lui appartient.
+        let start = civility_index(&self.inner_lines)
+            .map(|i| {
+                if i > 0 && is_legal_form(&self.inner_lines[i - 1]) {
+                    i - 1
+                } else {
+                    i
+                }
+            })
+            .unwrap_or(0);
+
+        self.inner_lines[start..]
+            .to_vec()
             .into_iter()
             .map(|line| {
                 if line.contains(':') {
@@ -39,7 +68,10 @@ impl Addr {
 
 pub fn find_account_holder_addr(text: &str) -> Option<Addr> {
     let lines: Vec<&str> = text.split("\n").collect();
-    let code_postal = Regex::new(r"(^| )\d{5} ([[:alpha:]]+ ?)+").unwrap();
+    // Le code postal peut être collé à la ville ou séparé d'elle par un tiret : les
+    // chaînes éditiques bancaires produisent l'un comme l'autre. Sans cette tolérance,
+    // le bloc n'est pas ancré et le repli sur le libellé le tronque.
+    let code_postal = Regex::new(r"(^| )\d{5}( ?- ?| ?)([[:alpha:]]+ ?)+").unwrap();
     let patch_upper_limit =
         Regex::new(r"(?i)(titulaire|intitulé|domiciliation|cadre réservé)").unwrap();
 
@@ -147,6 +179,78 @@ mod tests {
         ];
 
         test_file(path, account_holder);
+    }
+
+    /// Les chaînes éditiques collent parfois le code postal à la ville, ou les séparent
+    /// d'un tiret. Le bloc doit rester ancré.
+    #[test]
+    fn postal_code_glued_or_dashed_still_anchors_the_block() {
+        let glued = "Titulaire du compte\nM MATISSE HENRI\n51 RUE BERNARD ROY\n44100NANTES";
+        let dashed = "Titulaire du compte\nM MATISSE HENRI\n51 RUE BERNARD ROY\n44100 - NANTES";
+
+        assert_eq!(
+            find_account_holder_addr(glued).map(|a| a.lines()),
+            Some(vec_to_string(vec![
+                "M MATISSE HENRI",
+                "51 RUE BERNARD ROY",
+                "44100NANTES"
+            ]))
+        );
+        assert_eq!(
+            find_account_holder_addr(dashed).map(|a| a.lines()),
+            Some(vec_to_string(vec![
+                "M MATISSE HENRI",
+                "51 RUE BERNARD ROY",
+                "44100 - NANTES"
+            ]))
+        );
+    }
+
+    /// Sans mot-clé au-dessus du bloc, la remontée avalait la référence client et la
+    /// date d'édition posées dans la même colonne. La civilité borne le titulaire.
+    #[test]
+    fn lines_above_the_civility_are_dropped() {
+        let text = "Ref client 0123456789\nEdite le 12/03/2025\n\nM MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES";
+
+        assert_eq!(
+            find_account_holder_addr(text).map(|a| a.lines()),
+            Some(vec_to_string(vec![
+                "M MATISSE HENRI",
+                "51 RUE BERNARD ROY",
+                "44100 NANTES"
+            ]))
+        );
+    }
+
+    /// Une raison sociale juste au-dessus de la civilité fait partie du titulaire.
+    #[test]
+    fn a_legal_form_above_the_civility_is_kept() {
+        let text = "Titulaire\nSCI LES TILLEULS\nM MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES";
+
+        assert_eq!(
+            find_account_holder_addr(text).map(|a| a.lines()),
+            Some(vec_to_string(vec![
+                "SCI LES TILLEULS",
+                "M MATISSE HENRI",
+                "51 RUE BERNARD ROY",
+                "44100 NANTES"
+            ]))
+        );
+    }
+
+    /// Sans civilité — personne morale seule — rien n'est retiré.
+    #[test]
+    fn without_civility_the_block_is_untouched() {
+        let text = "Titulaire\nSAS HENRI MATISSE\n18 RUE SADI CARNOT\n92120 MONTROUGE";
+
+        assert_eq!(
+            find_account_holder_addr(text).map(|a| a.lines()),
+            Some(vec_to_string(vec![
+                "SAS HENRI MATISSE",
+                "18 RUE SADI CARNOT",
+                "92120 MONTROUGE"
+            ]))
+        );
     }
 
     #[test]

--- a/src/text/address.rs
+++ b/src/text/address.rs
@@ -75,22 +75,28 @@ pub fn find_account_holder_addr(text: &str) -> Option<Addr> {
     let patch_upper_limit =
         Regex::new(r"(?i)(titulaire|intitulé|domiciliation|cadre réservé)").unwrap();
 
+    // Deux blocs adressés côte à côte — titulaire d'un côté, agence de l'autre — mettent
+    // deux codes postaux sur la même ligne. N'examiner que le premier, c'est ne voir que
+    // le bloc de gauche, et donc rater le titulaire dès qu'il est à droite.
     let patches = lines
         .clone()
         .into_iter()
         .enumerate()
         .flat_map(|(index, line)| {
-            code_postal.find(line).map(|m| {
-                Patch::extract(
-                    &lines,
-                    index,
-                    &patch_upper_limit,
-                    m.start(),
-                    m.end() - 1,
-                    true,
-                    3,
-                )
-            })
+            code_postal
+                .find_iter(line)
+                .map(|m| {
+                    Patch::extract(
+                        &lines,
+                        index,
+                        &patch_upper_limit,
+                        m.start(),
+                        m.end() - 1,
+                        true,
+                        3,
+                    )
+                })
+                .collect::<Vec<Patch>>()
         });
 
     let addresses = patches.map(|p| {
@@ -202,6 +208,28 @@ mod tests {
                 "M MATISSE HENRI",
                 "51 RUE BERNARD ROY",
                 "44100 - NANTES"
+            ]))
+        );
+    }
+
+    /// Titulaire à droite d'une domiciliation qui porte elle aussi un code postal : les
+    /// deux blocs mettent deux codes postaux sur la même ligne, et seul le premier était
+    /// examiné. Le titulaire était systématiquement raté dès qu'il était à droite.
+    #[test]
+    fn a_holder_to_the_right_of_a_branch_address_is_found() {
+        let text = "\
+  Domiciliation                             Titulaire du compte (Account Owner)
+  CIC NANTES VOLTAIRE                       MLE PRENOM NOM
+  4 RUE VOLTAIRE                            9 RUE UN NOM EN PLUSIEURS MOT
+  44000 NANTES                              44100 NANTES
+  tel";
+
+        assert_eq!(
+            find_account_holder_addr(text).map(|a| a.lines()),
+            Some(vec_to_string(vec![
+                "MLE PRENOM NOM",
+                "9 RUE UN NOM EN PLUSIEURS MOT",
+                "44100 NANTES"
             ]))
         );
     }

--- a/src/text/address.rs
+++ b/src/text/address.rs
@@ -50,8 +50,8 @@ impl Addr {
             .unwrap_or(0);
 
         self.inner_lines[start..]
-            .to_vec()
-            .into_iter()
+            .iter()
+            .cloned()
             .map(|line| {
                 if line.contains(':') {
                     line.split(':').nth(1).unwrap().to_string()

--- a/src/text/simple_account_holder.rs
+++ b/src/text/simple_account_holder.rs
@@ -2,9 +2,24 @@ use regex::Regex;
 
 use super::patch::{right_complete, Patch};
 
+/// Un titulaire tient rarement en plus de six lignes : libellé, deux noms, complément,
+/// voie, ville. Au-delà, on est sorti du bloc.
+const MAX_HOLDER_LINES: usize = 6;
+
+/// `nb_line` borne le bloc quand rien d'autre ne l'arrête. Le bloc s'étend en dessous du
+/// libellé jusqu'à une frontière — ligne vide, mot-clé, IBAN ou BIC — ou jusqu'à cette
+/// borne, la première atteinte l'emportant.
+///
+/// Un plafond fixe de trois lignes coupait un couple suivi de son adresse dès que le code
+/// postal n'était pas reconnu : le libellé comptant pour une ligne, il ne restait que le
+/// nom.
 pub fn find_simple_account_holder(text: &str, nb_line: usize) -> Option<String> {
     let account_holder = Regex::new(r"(?i)(titulaire)").unwrap();
-    let stop = Regex::new(r"(?i)(domiciliation|cadre réservé|identification)").unwrap();
+    // l'IBAN et le BIC ferment le bloc : ils suivent souvent le titulaire directement
+    let stop = Regex::new(
+        r"(?i)(domiciliation|cadre réservé|identification|\bIBAN\b|\bBIC\b|FR\d{2} ?\d{4})",
+    )
+    .unwrap();
     let lines: Vec<&str> = text.lines().collect();
 
     let result = if let Some((index, m)) = lines.iter().enumerate().find_map(|(i, line)| {
@@ -17,7 +32,18 @@ pub fn find_simple_account_holder(text: &str, nb_line: usize) -> Option<String> 
         let start = m.start();
         let end = m.end();
 
-        let patch = Patch::extract(&lines, index, &stop, start, end - 1, false, nb_line);
+        // le bloc court jusqu'à la première ligne vide sous le libellé, ou jusqu'à la
+        // borne haute — plutôt que jusqu'à un compte fixe
+        let block_end = lines
+            .iter()
+            .enumerate()
+            .skip(index + 1)
+            .find(|(_, line)| line.trim().is_empty())
+            .map(|(i, _)| i)
+            .unwrap_or(lines.len());
+        let span = (block_end - index).clamp(nb_line, MAX_HOLDER_LINES);
+
+        let patch = Patch::extract(&lines, index, &stop, start, end - 1, false, span);
         clean(patch.lines())
     } else {
         None
@@ -45,9 +71,12 @@ pub fn find_simple_account_holder(text: &str, nb_line: usize) -> Option<String> 
 
 fn clean(lines: Vec<String>) -> Option<Vec<String>> {
     let account_holder = Regex::new(r"(?i)(titulaire)").unwrap();
-    let headers =
-        Regex::new(r"(?i)(titulaire|domiciliation|cadre réservé|identification|numero de)")
-            .unwrap();
+    // Les frontières qui ont arrêté le bloc en font partie : on les retire ici, IBAN et
+    // BIC compris — ils suivent souvent le titulaire sans ligne vide.
+    let headers = Regex::new(
+        r"(?i)(titulaire|domiciliation|cadre réservé|identification|numero de|\bIBAN\b|\bBIC\b|FR\d{2} ?\d{4})",
+    )
+    .unwrap();
 
     let vec: Vec<String> = lines
         .into_iter()
@@ -75,5 +104,54 @@ fn clean(lines: Vec<String>) -> Option<Vec<String>> {
         None
     } else {
         Some(vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sans code postal reconnu, le repli tronquait le bloc à deux lignes de contenu :
+    /// le libellé comptait pour une, et le plafond était de trois.
+    #[test]
+    fn a_couple_with_address_is_kept_whole_without_postal_code() {
+        let text = "Titulaire du compte\nM MATISSE HENRI\nOU MME KAHLO FRIDA\n51 RUE BERNARD ROY\nNANTES CEDEX 1\nIBAN FR76 3000 1000 6449 1900 9562 088";
+
+        assert_eq!(
+            find_simple_account_holder(text, 3).as_deref(),
+            Some("M MATISSE HENRI\nOU MME KAHLO FRIDA\n51 RUE BERNARD ROY\nNANTES CEDEX 1")
+        );
+    }
+
+    /// L'IBAN et le BIC ferment le bloc et n'en font pas partie.
+    #[test]
+    fn iban_and_bic_close_the_block() {
+        let text = "Titulaire\nM MATISSE HENRI\nBP 1234\nNANTES\nIBAN FR76 3000 1000 6449 1900 9562 088\nBIC SOGEFRPP";
+
+        assert_eq!(
+            find_simple_account_holder(text, 3).as_deref(),
+            Some("M MATISSE HENRI\nBP 1234\nNANTES")
+        );
+    }
+
+    /// Une ligne vide ferme le bloc.
+    #[test]
+    fn a_blank_line_closes_the_block() {
+        let text =
+            "Titulaire\nM MATISSE HENRI\n51 RUE BERNARD ROY\n\nDomiciliation\nAGENCE DE NANTES";
+
+        assert_eq!(
+            find_simple_account_holder(text, 3).as_deref(),
+            Some("M MATISSE HENRI\n51 RUE BERNARD ROY")
+        );
+    }
+
+    /// Le bloc ne dépasse jamais six lignes, quoi qu'il arrive.
+    #[test]
+    fn the_block_is_capped() {
+        let text = "Titulaire\nL1\nL2\nL3\nL4\nL5\nL6\nL7\nL8";
+        let found = find_simple_account_holder(text, 3).unwrap();
+
+        assert!(found.lines().count() <= MAX_HOLDER_LINES);
     }
 }

--- a/src/text/simple_account_holder.rs
+++ b/src/text/simple_account_holder.rs
@@ -78,11 +78,24 @@ fn clean(lines: Vec<String>) -> Option<Vec<String>> {
     )
     .unwrap();
 
+    // Le libellé peut être en tête de la ligne du nom sans deux-points pour les
+    // séparer : « TITULAIRE DU MME PRENOM NOM ». Jeter la ligne entière parce qu'elle
+    // porte le libellé, c'est jeter le titulaire avec. On retire le libellé, on garde
+    // le reste.
+    // Le libellé peut être suivi de sa traduction : « Titulaire du compte - Account
+    // Owner ». Elle est retirée avec lui.
+    let label_prefix = Regex::new(
+        r"(?i)^\s*(titulaire|intitul[eé])(\s+du|\s+de)?(\s+compte)?\s*([:\-/]\s*)?(\(?account\s+(owner|holder)\)?)?\s*[:\-]?\s*",
+    )
+    .unwrap();
+
     let vec: Vec<String> = lines
         .into_iter()
         .map(|line| {
             if account_holder.is_match(&line) && line.contains(':') {
                 line.split(':').nth(1).unwrap().to_string()
+            } else if account_holder.is_match(&line) {
+                label_prefix.replace(&line, "").to_string()
             } else {
                 line
             }
@@ -143,6 +156,19 @@ mod tests {
         assert_eq!(
             find_simple_account_holder(text, 3).as_deref(),
             Some("M MATISSE HENRI\n51 RUE BERNARD ROY")
+        );
+    }
+
+    /// Le libellé peut précéder le nom sur la même ligne, sans deux-points ; et se
+    /// poursuivre sur la ligne suivante (« TITULAIRE DU » / « COMPTE : »). Le titulaire
+    /// commence alors à droite du libellé, sur les deux lignes.
+    #[test]
+    fn a_label_split_over_two_lines_keeps_both_holder_lines() {
+        let text = "RELEVE D IDENTITE BANCAIRE\n\nTITULAIRE DU MME PRENOM NOM OU M\nCOMPTE :     PRENOM2 NOM2\n\nIBAN FR76";
+
+        assert_eq!(
+            find_simple_account_holder(text, 3).as_deref(),
+            Some("MME PRENOM NOM OU M\nPRENOM2 NOM2")
         );
     }
 


### PR DESCRIPTION
First of five stacked PRs. Each is mergeable on its own; the next one targets this one.

**What**

- two production bugs in account-holder extraction: multi-line holders were flattened to one line (holder accuracy 7 % → 62 % on synthetic corpus), and a block with a civility but no recognisable postal code panicked
- `extract_fr_bic` no longer mistakes an IBAN fragment (`NBICFR67190`) for a BIC
- `web::block` around the analysis: one slow request no longer freezes an actix worker
- three latency optimisations, all measured neutral on quality: no page re-recognition to find "titulaire", postal-code anchors ranked before cropping with early stop (138 → 96 ocrs calls on the photo corpus), IBAN anchor carried through rotation by geometry instead of a second tesseract hocr (tesseract 148 s → 86 s)
- RIB key arithmetic, IBAN-from-BBAN, `Rib` accessors
- holder block bounds on the text path; three real layouts reproduced and fixed; anchoring robust to a postal code glued to its city

**Measured** on the real photo corpus (32 docs, one job): median 13 s → 3.5 s, verdicts identical. MSRV unchanged (1.86), no dependency change.

**Not included**: anything measured and left out (orientation detection, OCR-to-grid projection, …) — see the `docs/experiences` PR.