### PR TITLE
feat: benchmark and synthetic corpus (feature "bench")

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,18 @@ url = "*"
 ocrs = "*"
 rten = "*"
 
+[features]
+# Outillage de mesure (generateur de corpus synthetique + banc). Hors du binaire de prod.
+bench = []
+
+[[bin]]
+name = "synth"
+required-features = ["bench"]
+
+[[bin]]
+name = "bench"
+required-features = ["bench"]
+
 [dev-dependencies]
 assert_cmd = "*"
 static_init = "*"

--- a/README.md
+++ b/README.md
@@ -11,3 +11,68 @@ L'exemple justificatif_de_domicile.png est issu de leur "Spécifications Techniq
 
 ocrs est utilisé pour l'OCR, il est nécessaire de télécharger ses models avant utilisation: ./download_models.sh .
 Cette opération est faite automatiquement lors du build en mode release.
+## Banc de mesure
+
+Le pipeline de reconnaissance de RIB enchaîne plusieurs stratégies (texte du PDF,
+OCR ocrs, recadrage autour d'une ancre, redressement puis tesseract). Aucune
+amélioration n'est évaluable sans mesure : le banc sert à comparer avant/après sur un
+corpus, et à savoir quelle branche produit réellement les succès.
+
+Il est bâti pour qu'un corpus de documents personnels puisse être mesuré **sans que son
+contenu ne figure dans le rapport**. Celui-ci ne porte que des verdicts et des grandeurs
+géométriques ; la garantie tient au typage de `bench::report::FileReport`, qui n'accepte
+aucun texte issu de la reconnaissance.
+
+### Corpus synthétique
+
+    cargo run --release --features bench --bin synth -- --out <dir> [--seed N] [--count N]
+
+Produit des RIB fictifs — IBAN structurellement valides (mod-97 et clé RIB) mais tirés
+au hasard — déclinés sur cinq gabarits, trois formes d'entrée (PDF natif, PDF scanné,
+photo) et une grille de dégradations paramétrées : résolution, inclinaison, perspective,
+flou, bruit, éclairage inégal, compression. La vérité terrain est écrite en même temps.
+
+La composition de la grille suit ce que le service reçoit réellement, établi sur deux
+corpus : des photos pour l'essentiel, des PDF issus des chaînes éditiques bancaires, et
+peu de scans. Ce sont les photos, non les scans, qui arrivent pivotées, et une photo
+porte toujours un support visible et un éclairage inégal — il n'existe pas de « photo
+propre ». Les PDF natifs restent peu nombreux malgré leur poids réel : reconnus sans
+OCR, donc toujours à 100 %, les sur-représenter diluerait les écarts que le banc doit
+rendre visibles. Le taux global n'est pas une estimation du taux de production, c'est un
+indicateur de régression.
+
+Chaque nom de fichier porte sa recette (`012_lcl_pdf_img_h14_rot30.pdf`), ce qui permet
+au banc de rendre des courbes plutôt qu'un taux global : à quelle hauteur de capitale, à
+quel angle, à quel niveau de bruit la reconnaissance cède.
+
+### Mesure
+
+    cargo run --release --features bench --bin bench -- \
+      --corpus <dir> [--truth <csv>] [--confusion] [--jobs N]
+
+La vérité terrain est un CSV `file;iban;bic;account_holder`, les lignes du titulaire
+séparées par `|`, les colonnes repérées par leur nom. Un champ vide sort du calcul du
+taux au lieu de compter comme un échec. Les colonnes facultatives `src`, `recipe` et
+`expect` ventilent les résultats ; `expect=known_failure` isole les cas connus pour
+échouer sans les compter comme des régressions.
+
+`--bootstrap` amorce ce fichier en ne retenant que les IBAN qui valident à la fois le
+mod-97 et la clé RIB, pour ne pas figer les erreurs du pipeline en référence.
+
+`--check` contrôle la forme du fichier sans rien mesurer : IBAN mal recopié (le mod-97
+le voit), clé RIB incohérente, BIC de forme inattendue, séparateur `|` oublié entre le
+nom et son adresse, ligne désignant un document absent du corpus. À lancer avant toute
+campagne de saisie — mesurer contre une référence fausse fait échouer le pipeline sur
+des lectures pourtant correctes.
+
+`--confusion` ajoute la matrice de confusion caractère, agrégée sur tout le corpus, et
+la distribution des positions d'erreur — émises séparément, jamais jointes.
+
+
+### Non-régression
+
+`tests/bench_synth.rs` vérifie en intégration continue que les PDF natifs sont reconnus
+intégralement et que le rapport ne laisse rien fuiter. La mesure complète, OCR compris,
+demande tesseract et les modèles ocrs :
+
+    cargo test --release --features bench --test bench_synth -- --ignored --nocapture

--- a/src/bench/check.rs
+++ b/src/bench/check.rs
@@ -1,0 +1,320 @@
+//! Contrôle de forme d'une vérité terrain.
+//!
+//! Saisir une vérité terrain à la main est fastidieux et silencieusement faillible : un
+//! chiffre d'IBAN inversé, un séparateur oublié, un nom de fichier approximatif, et le
+//! banc mesure contre une référence fausse sans jamais s'en plaindre.
+//!
+//! Ce contrôle exploite la redondance de l'IBAN pour attraper ces erreurs, et ne rend
+//! que des verdicts : il peut être lancé sur un corpus personnel et son résultat
+//! transmis tel quel.
+
+use std::path::Path;
+
+use regex::Regex;
+
+use crate::rib::{check_rib_key, normalize_iban};
+
+use super::truth::{normalize_bic, TruthSet};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum IbanCheck {
+    Missing,
+    /// Un IBAN français fait 27 caractères.
+    BadLength(usize),
+    NotFrench,
+    /// Échoue la clé de contrôle internationale : au moins un caractère est faux.
+    BadChecksum,
+    /// Passe le mod-97 mais pas la clé RIB nationale : deux erreurs se compensent,
+    /// ou la clé a été recopiée de travers.
+    BadRibKey,
+    Ok,
+}
+
+impl IbanCheck {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            IbanCheck::Missing => "-",
+            IbanCheck::BadLength(_) => "longueur",
+            IbanCheck::NotFrench => "pas FR",
+            IbanCheck::BadChecksum => "mod-97 KO",
+            IbanCheck::BadRibKey => "clé RIB KO",
+            IbanCheck::Ok => "OK",
+        }
+    }
+
+    pub fn is_problem(&self) -> bool {
+        !matches!(self, IbanCheck::Ok | IbanCheck::Missing)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum BicCheck {
+    Missing,
+    BadForm,
+    Ok,
+}
+
+impl BicCheck {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BicCheck::Missing => "-",
+            BicCheck::BadForm => "forme",
+            BicCheck::Ok => "OK",
+        }
+    }
+
+    pub fn is_problem(&self) -> bool {
+        matches!(self, BicCheck::BadForm)
+    }
+}
+
+pub struct LineCheck {
+    pub file: String,
+    /// Faux si aucun document de ce nom n'existe dans le corpus.
+    pub present: bool,
+    pub iban: IbanCheck,
+    pub bic: BicCheck,
+    pub holder_lines: usize,
+    /// Un code postal au-delà de la première ligne suggère une adresse correctement
+    /// découpée ; sur la première ligne seule, c'est un séparateur oublié.
+    pub holder_has_postal_code: bool,
+}
+
+impl LineCheck {
+    /// Adresse vraisemblablement collée au nom, faute de séparateur `|`.
+    pub fn holder_looks_unsplit(&self) -> bool {
+        self.holder_lines == 1 && self.holder_has_postal_code
+    }
+
+    pub fn has_problem(&self) -> bool {
+        !self.present
+            || self.iban.is_problem()
+            || self.bic.is_problem()
+            || self.holder_looks_unsplit()
+    }
+}
+
+fn check_iban(iban: Option<&String>) -> IbanCheck {
+    let Some(iban) = iban else {
+        return IbanCheck::Missing;
+    };
+
+    let normalized = normalize_iban(iban);
+
+    if !normalized.starts_with("FR") {
+        return IbanCheck::NotFrench;
+    }
+
+    if normalized.len() != 27 {
+        return IbanCheck::BadLength(normalized.len());
+    }
+
+    if normalized.parse::<iban::Iban>().is_err() {
+        return IbanCheck::BadChecksum;
+    }
+
+    if !check_rib_key(&normalized) {
+        return IbanCheck::BadRibKey;
+    }
+
+    IbanCheck::Ok
+}
+
+fn check_bic(bic: Option<&String>) -> BicCheck {
+    let Some(bic) = bic else {
+        return BicCheck::Missing;
+    };
+
+    let normalized = normalize_bic(bic);
+
+    // 4 lettres d'établissement, 2 de pays, 2 alphanumériques, et 3 en option
+    let form = Regex::new(r"^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$").unwrap();
+
+    if form.is_match(&normalized) {
+        BicCheck::Ok
+    } else {
+        BicCheck::BadForm
+    }
+}
+
+pub fn check(corpus: &Path, truths: &TruthSet) -> Vec<LineCheck> {
+    let postal_code = Regex::new(r"\b\d{5}\b").unwrap();
+
+    let mut checks: Vec<LineCheck> = truths
+        .entries()
+        .map(|(file, truth)| {
+            let holder_lines: Vec<&str> = truth
+                .holder
+                .as_deref()
+                .map(|holder| holder.lines().filter(|l| !l.trim().is_empty()).collect())
+                .unwrap_or_default();
+
+            LineCheck {
+                file: file.clone(),
+                present: corpus.join(file).is_file(),
+                iban: check_iban(truth.iban.as_ref()),
+                bic: check_bic(truth.bic.as_ref()),
+                holder_lines: holder_lines.len(),
+                holder_has_postal_code: holder_lines.iter().any(|line| postal_code.is_match(line)),
+            }
+        })
+        .collect();
+
+    checks.sort_by(|a, b| a.file.cmp(&b.file));
+
+    checks
+}
+
+/// Rendu ne portant que des verdicts, des comptes et des noms de fichiers.
+pub fn render(checks: &[LineCheck]) -> String {
+    let mut out = format!(
+        "{:<28} {:<8} {:<12} {:<8} {:<12}\n",
+        "file", "présent", "iban", "bic", "titulaire"
+    );
+
+    for check in checks {
+        let holder = match check.holder_lines {
+            0 => "-".to_string(),
+            1 if check.holder_has_postal_code => "1 ligne (?)".to_string(),
+            n => format!("{} lignes", n),
+        };
+
+        out.push_str(&format!(
+            "{:<28} {:<8} {:<12} {:<8} {:<12}\n",
+            check.file,
+            if check.present { "oui" } else { "NON" },
+            check.iban.as_str(),
+            check.bic.as_str(),
+            holder
+        ));
+    }
+
+    let filled = checks
+        .iter()
+        .filter(|c| c.iban != IbanCheck::Missing)
+        .count();
+    let problems: Vec<&LineCheck> = checks.iter().filter(|c| c.has_problem()).collect();
+
+    out.push_str(&format!(
+        "\n{} ligne(s) sur {} portent un IBAN\n",
+        filled,
+        checks.len()
+    ));
+
+    if problems.is_empty() {
+        out.push_str("Aucune anomalie de forme.\n");
+        return out;
+    }
+
+    out.push_str(&format!("\n{} anomalie(s) :\n", problems.len()));
+
+    for problem in problems {
+        if !problem.present {
+            out.push_str(&format!(
+                "  {} : aucun document de ce nom dans le corpus\n",
+                problem.file
+            ));
+        }
+        if problem.iban.is_problem() {
+            out.push_str(&format!(
+                "  {} : IBAN {} — vérifier la recopie\n",
+                problem.file,
+                problem.iban.as_str()
+            ));
+        }
+        if problem.bic.is_problem() {
+            out.push_str(&format!("  {} : BIC de forme inattendue\n", problem.file));
+        }
+        if problem.holder_looks_unsplit() {
+            out.push_str(&format!(
+                "  {} : titulaire sur une seule ligne alors qu'il porte un code postal —\n           \
+                 séparateur `|` probablement oublié entre le nom et l'adresse\n",
+                problem.file
+            ));
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static IBAN: &str = "FR7630001000644919009562088";
+
+    #[test]
+    fn a_well_formed_iban_passes_both_checksums() {
+        assert_eq!(check_iban(Some(&IBAN.to_string())), IbanCheck::Ok);
+        assert_eq!(
+            check_iban(Some(&"FR76 3000 1000 6449 1900 9562 088".to_string())),
+            IbanCheck::Ok
+        );
+        assert_eq!(check_iban(None), IbanCheck::Missing);
+    }
+
+    /// Le cas que le contrôle existe pour attraper : deux chiffres intervertis à la
+    /// saisie. La clé internationale suffit à le voir.
+    #[test]
+    fn a_transcription_error_is_caught() {
+        assert_eq!(
+            check_iban(Some(&"FR7630001000644919009562880".to_string())),
+            IbanCheck::BadChecksum
+        );
+        assert_eq!(
+            check_iban(Some(&"FR763000100064491900956208".to_string())),
+            IbanCheck::BadLength(26)
+        );
+        assert_eq!(
+            check_iban(Some(&"DE89370400440532013000".to_string())),
+            IbanCheck::NotFrench
+        );
+    }
+
+    #[test]
+    fn bic_form_is_validated_but_not_invented() {
+        assert_eq!(check_bic(Some(&"SOGEFRPP".to_string())), BicCheck::Ok);
+        assert_eq!(check_bic(Some(&"BOUS FRPP XXX".to_string())), BicCheck::Ok);
+        assert_eq!(check_bic(Some(&"SOGE".to_string())), BicCheck::BadForm);
+        assert_eq!(check_bic(None), BicCheck::Missing);
+    }
+
+    #[test]
+    fn a_holder_glued_to_its_address_is_flagged() {
+        let unsplit = LineCheck {
+            file: "1.jpeg".to_string(),
+            present: true,
+            iban: IbanCheck::Ok,
+            bic: BicCheck::Ok,
+            holder_lines: 1,
+            holder_has_postal_code: true,
+        };
+
+        assert!(unsplit.holder_looks_unsplit());
+        assert!(unsplit.has_problem());
+
+        let split = LineCheck {
+            holder_lines: 3,
+            ..unsplit
+        };
+
+        assert!(!split.holder_looks_unsplit());
+        assert!(!split.has_problem());
+    }
+
+    /// Un titulaire d'une seule ligne sans adresse est parfaitement normal.
+    #[test]
+    fn a_name_without_address_is_not_flagged() {
+        let name_only = LineCheck {
+            file: "2.jpg".to_string(),
+            present: true,
+            iban: IbanCheck::Ok,
+            bic: BicCheck::Ok,
+            holder_lines: 1,
+            holder_has_postal_code: false,
+        };
+
+        assert!(!name_only.holder_looks_unsplit());
+        assert!(!name_only.has_problem());
+    }
+}

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -1,0 +1,280 @@
+//! Banc de mesure de la reconnaissance de RIB.
+//!
+//! Exécute le pipeline de production sur un corpus, confronte le résultat à une vérité
+//! terrain qui ne quitte jamais la machine, et n'émet que des verdicts et des grandeurs
+//! géométriques. Un corpus de documents personnels peut donc être mesuré sans que rien
+//! de leur contenu ne figure dans le rapport.
+
+pub mod check;
+pub mod profile;
+pub mod report;
+pub mod truth;
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Instant;
+
+use crate::analysis::vec_to_rib_traced;
+use crate::provenance::Provenance;
+use crate::rib::{check_rib_key, normalize_iban, Rib};
+
+use report::{Confusion, Failure, FileReport, Report};
+use truth::{TruthSet, Verdict};
+
+/// Documents du corpus, triés pour que deux exécutions soient comparables ligne à ligne.
+pub fn corpus_files(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let entries = fs::read_dir(dir).map_err(|e| format!("lecture de {} : {}", dir.display(), e))?;
+
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name != "truth.csv" && !name.starts_with('.'))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    files.sort();
+
+    Ok(files)
+}
+
+fn file_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("inconnu")
+        .to_string()
+}
+
+fn analyse(path: &Path) -> (Option<Rib>, Provenance, Option<Failure>, u64) {
+    let mut provenance = Provenance::default();
+
+    let Ok(content) = fs::read(path) else {
+        return (None, provenance, Some(Failure::Unreadable), 0);
+    };
+
+    crate::timing::reset();
+    let started = Instant::now();
+    let outcome = vec_to_rib_traced(content, &file_name(path), &mut provenance);
+    let duration = started.elapsed().as_millis() as u64;
+    provenance.timings = crate::timing::snapshot();
+
+    match outcome {
+        Ok(rib) => (rib, provenance, None, duration),
+        Err(_) => (None, provenance, Some(Failure::UnsupportedType), duration),
+    }
+}
+
+/// Isole chaque document : un `unwrap` malheureux sur un cas particulier ne doit pas
+/// emporter la mesure des autres, surtout sur un corpus qu'on ne peut pas inspecter.
+fn measure(path: &Path, truths: &TruthSet, confusion: Option<&Mutex<Confusion>>) -> FileReport {
+    let measured = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        measure_unguarded(path, truths, confusion)
+    }));
+
+    measured.unwrap_or_else(|_| {
+        let mut file = FileReport::from_provenance(file_name(path), &Provenance::default());
+        file.failure = Some(Failure::Panicked);
+        file
+    })
+}
+
+fn measure_unguarded(
+    path: &Path,
+    truths: &TruthSet,
+    confusion: Option<&Mutex<Confusion>>,
+) -> FileReport {
+    let (rib, provenance, failure, duration) = analyse(path);
+    let name = file_name(path);
+
+    let mut file = FileReport::from_provenance(name.clone(), &provenance);
+    file.duration_ms = duration;
+    file.failure = failure;
+
+    let Some(truth) = truths.get(&name) else {
+        return file;
+    };
+
+    let found_iban = rib.as_ref().map(|r| r.iban());
+
+    file.iban = truth.iban_verdict(found_iban);
+    file.bic = truth.bic_verdict(rib.as_ref().and_then(|r| r.bic()));
+    file.holder_strict = truth.holder_strict_verdict(rib.as_ref().and_then(|r| r.account_holder()));
+    file.holder_loose = truth.holder_loose_verdict(rib.as_ref().and_then(|r| r.account_holder()));
+    file.holder_content =
+        truth.holder_content_verdict(rib.as_ref().and_then(|r| r.account_holder()));
+
+    if file.holder_loose == Verdict::Ko {
+        if let (Some(expected), Some(found)) = (
+            truth.holder.as_ref(),
+            rib.as_ref().and_then(|r| r.account_holder()),
+        ) {
+            file.holder_mismatch = Some(truth::classify_holder_mismatch(expected, found));
+        }
+    }
+    file.known_failure = truth.known_failure;
+    file.src = truth.src.clone();
+    file.recipe = truth.recipe.clone();
+
+    if file.iban == Verdict::Ko {
+        if let (Some(confusion), Some(expected), Some(found)) =
+            (confusion, truth.iban.as_ref(), found_iban)
+        {
+            confusion
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .observe(&normalize_iban(expected), &normalize_iban(found));
+        }
+    }
+
+    file
+}
+
+/// Mesure le corpus. `jobs` fixe le nombre de documents traités de front.
+pub fn run(
+    dir: &Path,
+    truths: &TruthSet,
+    with_confusion: bool,
+    jobs: usize,
+) -> Result<Report, String> {
+    let files = corpus_files(dir)?;
+    let confusion = Mutex::new(Confusion::default());
+    let jobs = jobs.max(1).min(files.len().max(1));
+
+    let confusion_ref = if with_confusion {
+        Some(&confusion)
+    } else {
+        None
+    };
+
+    let results: Vec<Vec<(usize, FileReport)>> = std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..jobs)
+            .map(|job| {
+                let files = &files;
+                let truths = &truths;
+
+                scope.spawn(move || {
+                    files
+                        .iter()
+                        .enumerate()
+                        .skip(job)
+                        .step_by(jobs)
+                        .map(|(index, path)| (index, measure(path, truths, confusion_ref)))
+                        .collect::<Vec<(usize, FileReport)>>()
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread de mesure"))
+            .collect()
+    });
+
+    let mut indexed: Vec<(usize, FileReport)> = results.into_iter().flatten().collect();
+    indexed.sort_by_key(|(index, _)| *index);
+
+    Ok(Report {
+        files: indexed.into_iter().map(|(_, file)| file).collect(),
+        confusion: confusion
+            .into_inner()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()),
+    })
+}
+
+/// Pré-remplit une vérité terrain à partir de ce que le pipeline trouve, en ne retenant
+/// que les IBAN qui valident à la fois le mod-97 et la clé RIB.
+///
+/// Sans ce filtre, les erreurs actuelles se figeraient en référence et le banc
+/// mesurerait sa propre complaisance.
+pub fn bootstrap(dir: &Path, jobs: usize) -> Result<String, String> {
+    let files = corpus_files(dir)?;
+    let jobs = jobs.max(1).min(files.len().max(1));
+
+    let rows: Vec<Vec<(usize, String)>> =
+        std::thread::scope(|scope| {
+            let handles: Vec<_> =
+                (0..jobs)
+                    .map(|job| {
+                        let files = &files;
+
+                        scope.spawn(move || {
+                            files
+                                .iter()
+                                .enumerate()
+                                .skip(job)
+                                .step_by(jobs)
+                                .map(|(index, path)| {
+                                    let (rib, _, _, _) = std::panic::catch_unwind(
+                                        std::panic::AssertUnwindSafe(|| analyse(path)),
+                                    )
+                                    .unwrap_or((None, Provenance::default(), None, 0));
+
+                                    let trusted = rib.as_ref().filter(|rib| {
+                                        let iban = normalize_iban(rib.iban());
+                                        iban.parse::<iban::Iban>().is_ok() && check_rib_key(&iban)
+                                    });
+
+                                    let row = format!(
+                                        "{};{};{};\n",
+                                        file_name(path),
+                                        trusted
+                                            .map(|r| normalize_iban(r.iban()))
+                                            .unwrap_or_default(),
+                                        trusted
+                                            .and_then(|r| r.bic())
+                                            .map(truth::normalize_bic)
+                                            .unwrap_or_default(),
+                                    );
+
+                                    (index, row)
+                                })
+                                .collect::<Vec<(usize, String)>>()
+                        })
+                    })
+                    .collect();
+
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("thread d'amorçage"))
+                .collect()
+        });
+
+    let mut indexed: Vec<(usize, String)> = rows.into_iter().flatten().collect();
+    indexed.sort_by_key(|(index, _)| *index);
+
+    let mut out = String::from("file;iban;bic;account_holder\n");
+    for (_, row) in indexed {
+        out.push_str(&row);
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn corpus_listing_excludes_the_truth_file() {
+        let dir = std::env::temp_dir().join("la_taupe_corpus_listing");
+        fs::create_dir_all(&dir).unwrap();
+
+        fs::write(dir.join("truth.csv"), "file\n").unwrap();
+        fs::write(dir.join("b.pdf"), "x").unwrap();
+        fs::write(dir.join("a.pdf"), "x").unwrap();
+        fs::write(dir.join(".hidden"), "x").unwrap();
+
+        let files = corpus_files(&dir).unwrap();
+
+        assert_eq!(files.len(), 2);
+        assert_eq!(file_name(&files[0]), "a.pdf");
+        assert_eq!(file_name(&files[1]), "b.pdf");
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/bench/profile.rs
+++ b/src/bench/profile.rs
@@ -1,0 +1,183 @@
+//! Profil de forme du texte reconnu, agrégé sur un corpus.
+//!
+//! Le taux de réussite transfère du corpus synthétique au réel, mais la nature des
+//! échecs, elle, ne transfère pas : deux chantiers ont corrigé des défaillances qui
+//! n'existaient que dans le corpus généré. Comparer les taux ne suffit donc pas — il faut
+//! comparer ce que l'OCR produit.
+//!
+//! Le pipeline consigne pour chaque document des comptages de forme (`TextStats`) —
+//! proportion de chiffres, longueur des lignes, part de vocabulaire retrouvé,
+//! fragmentation — sans conserver le texte. Ce module les résume en distributions, que
+//! deux corpus se comparent directement.
+
+use std::collections::BTreeMap;
+
+use crate::provenance::TextStats;
+
+#[derive(Debug, Default, Clone)]
+pub struct Distribution {
+    pub mean: f32,
+    pub p25: f32,
+    pub median: f32,
+    pub p75: f32,
+}
+
+impl Distribution {
+    fn of(mut values: Vec<f32>) -> Self {
+        if values.is_empty() {
+            return Distribution::default();
+        }
+
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let at = |q: f32| values[((values.len() - 1) as f32 * q).round() as usize];
+
+        Distribution {
+            mean: values.iter().sum::<f32>() / values.len() as f32,
+            p25: at(0.25),
+            median: at(0.5),
+            p75: at(0.75),
+        }
+    }
+}
+
+/// Distributions des grandeurs de forme sur un ensemble de documents.
+#[derive(Debug, Default)]
+pub struct ProfileSummary {
+    pub count: usize,
+    pub metrics: Vec<(&'static str, Distribution)>,
+}
+
+fn ratio(n: u32, d: u32) -> f32 {
+    if d == 0 {
+        0.0
+    } else {
+        n as f32 / d as f32
+    }
+}
+
+impl ProfileSummary {
+    pub fn of(stats: &[&TextStats]) -> Self {
+        let collect =
+            |f: fn(&TextStats) -> f32| Distribution::of(stats.iter().map(|s| f(s)).collect());
+
+        let metrics = vec![
+            ("lignes", collect(|s| s.lines as f32)),
+            ("mots", collect(|s| s.words as f32)),
+            ("caractères", collect(|s| s.chars as f32)),
+            ("part chiffres", collect(|s| ratio(s.digits, s.chars))),
+            ("part lettres", collect(|s| ratio(s.alphas, s.chars))),
+            ("part symboles", collect(|s| ratio(s.symbols, s.chars))),
+            ("long. ligne", collect(|s| ratio(s.chars, s.lines))),
+            ("lignes courtes", collect(|s| ratio(s.short_lines, s.lines))),
+            (
+                "mots 1 car.",
+                collect(|s| ratio(s.single_char_words, s.words)),
+            ),
+            ("mots mixtes", collect(|s| ratio(s.mixed_words, s.words))),
+            ("vocabulaire /12", collect(|s| s.vocabulary_hits as f32)),
+            (
+                "préfixe IBAN vu",
+                collect(|s| if s.has_iban_prefix { 1.0 } else { 0.0 }),
+            ),
+            (
+                "code postal vu",
+                collect(|s| if s.has_postal_code { 1.0 } else { 0.0 }),
+            ),
+        ];
+
+        ProfileSummary {
+            count: stats.len(),
+            metrics,
+        }
+    }
+
+    pub fn render(&self, title: &str) -> String {
+        let mut out = format!(
+            "\n{} ({} documents)\n  {:<16} {:>8} {:>8} {:>8} {:>8}\n",
+            title, self.count, "", "moyenne", "p25", "médiane", "p75"
+        );
+
+        for (name, d) in &self.metrics {
+            out.push_str(&format!(
+                "  {:<16} {:>8.2} {:>8.2} {:>8.2} {:>8.2}\n",
+                name, d.mean, d.p25, d.median, d.p75
+            ));
+        }
+
+        out
+    }
+}
+
+/// Résumés par groupe : les documents où l'IBAN a été trouvé contre ceux où il ne l'a
+/// pas été. C'est le contraste entre les deux qui dit à quoi ressemble un échec.
+pub fn grouped<'a>(
+    stats: impl Iterator<Item = (&'a str, &'a TextStats)>,
+) -> BTreeMap<&'a str, Vec<&'a TextStats>> {
+    let mut groups: BTreeMap<&str, Vec<&TextStats>> = BTreeMap::new();
+
+    for (group, stat) in stats {
+        groups.entry(group).or_default().push(stat);
+    }
+
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_clean_rib_has_a_recognisable_shape() {
+        let text = "RELEVE D'IDENTITE BANCAIRE\nTitulaire du compte\nM MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES\nIBAN FR76 3000 1000 6449 1900 9562 088\nBIC BDFEFRPPCCT";
+        let stats = TextStats::of(text);
+
+        assert_eq!(stats.lines, 7);
+        assert!(stats.vocabulary_hits >= 5, "{:?}", stats);
+        assert!(stats.has_iban_prefix);
+        assert!(stats.has_postal_code);
+        assert!(ratio(stats.symbols, stats.chars) < 0.05);
+        assert_eq!(stats.short_lines, 0);
+    }
+
+    #[test]
+    fn ocr_noise_shows_as_fragmentation_and_symbols() {
+        let text = "R.\n|\nT1tula1re\nM\n~\nFR76 3O00\n:\n.\n4A100 N4NTES";
+        let stats = TextStats::of(text);
+
+        assert!(ratio(stats.short_lines, stats.lines) > 0.4, "{:?}", stats);
+        assert!(ratio(stats.symbols, stats.chars) > 0.05, "{:?}", stats);
+        assert!(ratio(stats.mixed_words, stats.words) > 0.2, "{:?}", stats);
+    }
+
+    /// Les statistiques ne doivent jamais contenir de texte : que des nombres.
+    #[test]
+    fn stats_carry_no_content() {
+        let stats = TextStats::of("M MATISSE HENRI FR7630001000644919009562088");
+        let debug = format!("{:?}", stats);
+
+        assert!(!debug.contains("MATISSE"));
+        assert!(!debug.contains("FR76"));
+    }
+
+    #[test]
+    fn distribution_quartiles_are_ordered() {
+        let d = Distribution::of(vec![5.0, 1.0, 3.0, 4.0, 2.0]);
+
+        assert_eq!(d.median, 3.0);
+        assert!(d.p25 <= d.median && d.median <= d.p75);
+        assert!((d.mean - 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn summary_renders_one_line_per_metric() {
+        let a = TextStats::of("IBAN FR76 3000\n44100 NANTES");
+        let b = TextStats::of("R.\n|");
+        let summary = ProfileSummary::of(&[&a, &b]);
+
+        assert_eq!(summary.count, 2);
+        let rendered = summary.render("test");
+        assert!(rendered.contains("vocabulaire /12"));
+        assert!(rendered.contains("lignes courtes"));
+    }
+}

--- a/src/bench/report.rs
+++ b/src/bench/report.rs
@@ -1,0 +1,663 @@
+//! Rapport du banc.
+//!
+//! Garantie de confidentialité par le typage : hormis le nom du fichier et les
+//! métadonnées reprises de la vérité terrain, un `FileReport` ne contient que des
+//! nombres et des `&'static str`. Aucun texte reconnu ne peut donc y transiter, même
+//! par inadvertance — un futur champ dynamique ne compilerait pas sans qu'on l'ajoute
+//! explicitement ici.
+
+use std::collections::BTreeMap;
+
+use crate::provenance::{Provenance, TextStats};
+
+use super::profile::{grouped, ProfileSummary};
+use super::truth::{HolderMismatch, Verdict};
+
+/// Motif d'abandon, catégorisé plutôt que recopié : un message d'erreur brut pourrait
+/// contenir un fragment du document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Failure {
+    UnsupportedType,
+    Unreadable,
+    /// Le pipeline a paniqué sur ce document. Consigné comme un échec parmi d'autres :
+    /// une campagne sur corpus réel ne doit pas être perdue pour un cas pathologique.
+    Panicked,
+}
+
+impl Failure {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Failure::UnsupportedType => "type_non_supporte",
+            Failure::Unreadable => "illisible",
+            Failure::Panicked => "PANIQUE",
+        }
+    }
+}
+
+pub struct FileReport {
+    pub file: String,
+    pub iban: Verdict,
+    pub bic: Verdict,
+    pub holder_strict: Verdict,
+    pub holder_loose: Verdict,
+    /// Contenu identique une fois les espaces retirés : lu, même si mal segmenté.
+    pub holder_content: Verdict,
+    pub known_failure: bool,
+    /// Forme attendue, reprise de la vérité terrain.
+    pub src: Option<String>,
+    /// Recette de dégradation, reprise de la vérité terrain.
+    pub recipe: Option<String>,
+    pub route: Option<&'static str>,
+    pub engine: Option<&'static str>,
+    pub anchor: Option<&'static str>,
+    pub anchor_height: Option<u32>,
+    pub angle_deg: Option<f32>,
+    pub second_pass: bool,
+    pub postal_anchors: u32,
+    pub holder_candidates: u32,
+    pub holder_blocks_read: u32,
+    pub width: u32,
+    pub height: u32,
+    pub duration_ms: u64,
+    pub ocrs_ms: u64,
+    pub ocrs_calls: u32,
+    pub tess_ms: u64,
+    pub tess_calls: u32,
+    pub preprocess_ms: u64,
+    pub poppler_ms: u64,
+    pub failure: Option<Failure>,
+    /// Comptages de forme du texte reconnu — jamais le texte.
+    pub text_stats: Option<TextStats>,
+    /// Nature de l'écart quand le titulaire est faux.
+    pub holder_mismatch: Option<HolderMismatch>,
+}
+
+impl FileReport {
+    pub fn from_provenance(file: String, provenance: &Provenance) -> Self {
+        FileReport {
+            file,
+            iban: Verdict::NoTruth,
+            bic: Verdict::NoTruth,
+            holder_strict: Verdict::NoTruth,
+            holder_loose: Verdict::NoTruth,
+            holder_content: Verdict::NoTruth,
+            known_failure: false,
+            src: None,
+            recipe: None,
+            route: provenance.route.map(|r| r.as_str()),
+            engine: provenance.engine.map(|e| e.as_str()),
+            anchor: provenance.anchor.map(|a| a.as_str()),
+            anchor_height: provenance.anchor_height,
+            angle_deg: provenance.angle_deg,
+            second_pass: provenance.second_pass,
+            postal_anchors: provenance.postal_anchors,
+            holder_candidates: provenance.holder_candidates,
+            holder_blocks_read: provenance.holder_blocks_read,
+            width: provenance.image_width,
+            height: provenance.image_height,
+            duration_ms: 0,
+            ocrs_ms: provenance.timings.ocrs.as_millis() as u64,
+            ocrs_calls: provenance.timings.ocrs_calls,
+            tess_ms: provenance.timings.tesseract.as_millis() as u64,
+            tess_calls: provenance.timings.tesseract_calls,
+            preprocess_ms: provenance.timings.preprocess.as_millis() as u64,
+            poppler_ms: provenance.timings.poppler.as_millis() as u64,
+            failure: None,
+            text_stats: provenance.page_text_stats.clone(),
+            holder_mismatch: None,
+        }
+    }
+}
+
+fn optional<T: std::fmt::Display>(value: Option<T>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Matrice de confusion caractère et distribution des positions d'erreur, agrégées sur
+/// l'ensemble du corpus.
+///
+/// Les deux sont émises séparément et ne sont jamais jointes : un couple
+/// (position, caractère) sur un corpus réduit permettrait de reconstituer des fragments
+/// d'IBAN, ce que des agrégats séparés interdisent.
+#[derive(Default)]
+pub struct Confusion {
+    pairs: BTreeMap<(char, char), usize>,
+    positions: BTreeMap<usize, usize>,
+    length_mismatches: usize,
+}
+
+impl Confusion {
+    pub fn observe(&mut self, expected: &str, found: &str) {
+        if expected.len() != found.len() {
+            self.length_mismatches += 1;
+            return;
+        }
+
+        for (position, (a, b)) in expected.chars().zip(found.chars()).enumerate() {
+            if a != b {
+                *self.pairs.entry((a, b)).or_insert(0) += 1;
+                *self.positions.entry(position).or_insert(0) += 1;
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pairs.is_empty() && self.length_mismatches == 0
+    }
+
+    pub fn render(&self) -> String {
+        let mut out = String::from("\nConfusions caractère (agrégées sur le corpus)\n");
+
+        let mut pairs: Vec<(&(char, char), &usize)> = self.pairs.iter().collect();
+        pairs.sort_by(|a, b| b.1.cmp(a.1));
+
+        out.push_str("  attendu -> lu    n\n");
+        for ((expected, found), count) in pairs {
+            out.push_str(&format!(
+                "  {} -> {}         {:>4}\n",
+                expected, found, count
+            ));
+        }
+
+        let mut positions: Vec<(&usize, &usize)> = self.positions.iter().collect();
+        positions.sort_by(|a, b| b.1.cmp(a.1));
+
+        out.push_str("\nPositions d'erreur (agrégées, sans lien avec les caractères)\n");
+        out.push_str("  position    n\n");
+        for (position, count) in positions {
+            out.push_str(&format!("  {:>8}  {:>4}\n", position, count));
+        }
+
+        if self.length_mismatches > 0 {
+            out.push_str(&format!(
+                "\n  {} lectures de longueur différente, non alignables\n",
+                self.length_mismatches
+            ));
+        }
+
+        out
+    }
+}
+
+/// Distingue la valeur fausse de la valeur absente.
+///
+/// Le taux de réussite seul masque un progrès décisif : écarter un candidat erroné sans
+/// pour autant trouver le bon ne change rien au taux, alors qu'une donnée absente vaut
+/// bien mieux qu'une donnée fausse — celle-ci se propage en aval sans se signaler.
+#[derive(Default)]
+struct Tally {
+    ok: usize,
+    wrong: usize,
+    total: usize,
+}
+
+impl Tally {
+    fn add(&mut self, verdict: Verdict) {
+        if !verdict.counts() {
+            return;
+        }
+
+        self.total += 1;
+
+        match verdict {
+            Verdict::Ok => self.ok += 1,
+            Verdict::Ko => self.wrong += 1,
+            _ => {}
+        }
+    }
+
+    fn render(&self, label: &str) -> String {
+        if self.total == 0 {
+            return format!("  {:<16} aucun cas mesurable\n", label);
+        }
+
+        let wrong = if self.wrong > 0 {
+            format!("   dont {} faux", self.wrong)
+        } else {
+            String::new()
+        };
+
+        format!(
+            "  {:<16} {:>3}/{:<3} ({:.1} %){}\n",
+            label,
+            self.ok,
+            self.total,
+            100.0 * self.ok as f32 / self.total as f32,
+            wrong
+        )
+    }
+}
+
+pub struct Report {
+    pub files: Vec<FileReport>,
+    pub confusion: Confusion,
+}
+
+impl Report {
+    /// Une ligne par document. Rien de ce qui figure ici ne dépend du contenu reconnu.
+    pub fn render_files(&self) -> String {
+        let mut out = format!(
+            "{:<48} {:<5} {:<5} {:<7} {:<7} {:<10} {:<10} {:<12} {:<6} {:<7} {:<3} {:>7}\n",
+            "file",
+            "iban",
+            "bic",
+            "holder",
+            "holder~",
+            "kind",
+            "route",
+            "engine",
+            "anchor",
+            "anchor_h",
+            "2p",
+            "ms"
+        );
+
+        for file in &self.files {
+            out.push_str(&format!(
+                "{:<48} {:<5} {:<5} {:<7} {:<7} {:<10} {:<10} {:<12} {:<6} {:<7} {:<3} {:>7}\n",
+                file.file,
+                file.iban.as_str(),
+                file.bic.as_str(),
+                file.holder_strict.as_str(),
+                file.holder_loose.as_str(),
+                // nature de l'écart quand le titulaire est faux : dit quels documents
+                // méritent une lecture, sans rien dire de leur contenu
+                optional(file.holder_mismatch.map(|k| k.as_str())),
+                optional(file.route),
+                optional(file.engine.or(file.failure.map(|f| f.as_str()))),
+                optional(file.anchor),
+                optional(file.anchor_height),
+                if file.second_pass { "2" } else { "-" },
+                file.duration_ms
+            ));
+            // ventilation par document, quand elle est renseignée
+            if file.ocrs_calls + file.tess_calls > 0 {
+                out.push_str(&format!(
+                    "{:<48}   ocrs {:>3}× {:>6} ms · tess {:>2}× {:>6} ms · pré {:>5} ms · CP {}/{}/{}\n",
+                    "",
+                    file.ocrs_calls,
+                    file.ocrs_ms,
+                    file.tess_calls,
+                    file.tess_ms,
+                    file.preprocess_ms,
+                    file.postal_anchors,
+                    file.holder_candidates,
+                    file.holder_blocks_read
+                ));
+            }
+        }
+
+        out
+    }
+
+    /// Profil de forme du texte reconnu, ventilé selon que l'IBAN a été trouvé ou non.
+    /// C'est le contraste entre les deux groupes qui dit à quoi ressemble un échec, et
+    /// la comparaison de ces profils entre corpus qui dit si les échecs se ressemblent.
+    pub fn render_profiles(&self) -> String {
+        let with_stats = self
+            .files
+            .iter()
+            .filter(|f| !f.known_failure)
+            .filter_map(|f| f.text_stats.as_ref().map(|s| (f, s)));
+
+        let groups = grouped(with_stats.map(|(f, s)| {
+            let group = match f.iban {
+                Verdict::Ok => "IBAN trouvé",
+                Verdict::Ko => "IBAN faux",
+                Verdict::NotFound => "IBAN non trouvé",
+                Verdict::NoTruth => "sans vérité",
+            };
+            (group, s)
+        }));
+
+        if groups.is_empty() {
+            return String::new();
+        }
+
+        let mut out = String::new();
+        for (group, stats) in groups {
+            out.push_str(&ProfileSummary::of(&stats).render(group));
+        }
+
+        out
+    }
+
+    pub fn render_summary(&self) -> String {
+        let measurable: Vec<&FileReport> = self.files.iter().filter(|f| !f.known_failure).collect();
+
+        let mut iban = Tally::default();
+        let mut bic = Tally::default();
+        let mut strict = Tally::default();
+        let mut loose = Tally::default();
+        let mut content = Tally::default();
+
+        for file in &measurable {
+            iban.add(file.iban);
+            bic.add(file.bic);
+            strict.add(file.holder_strict);
+            loose.add(file.holder_loose);
+            content.add(file.holder_content);
+        }
+
+        let mut out = format!("\n{} documents analysés\n\n", self.files.len());
+
+        out.push_str("Taux de réussite\n");
+        out.push_str(&iban.render("IBAN"));
+        out.push_str(&bic.render("BIC"));
+        out.push_str(&strict.render("titulaire"));
+        out.push_str(&loose.render("titulaire souple"));
+        out.push_str(&content.render("titulaire contenu"));
+
+        let panicked = self
+            .files
+            .iter()
+            .filter(|f| f.failure == Some(Failure::Panicked))
+            .count();
+
+        if panicked > 0 {
+            out.push_str(&format!(
+                "\n  {} document(s) ont fait paniquer le pipeline — voir la colonne engine\n",
+                panicked
+            ));
+        }
+
+        let known: Vec<&FileReport> = self.files.iter().filter(|f| f.known_failure).collect();
+        if !known.is_empty() {
+            let unexpected = known.iter().filter(|f| f.iban.is_ok()).count();
+            out.push_str(&format!(
+                "\n  {} cas d'échec connu, hors du calcul ({} réussissent malgré tout)\n",
+                known.len(),
+                unexpected
+            ));
+        }
+
+        out.push_str(
+            &self.render_grouped("Réussite IBAN par forme d'entrée", |f| {
+                f.src.clone().unwrap_or_else(|| "-".to_string())
+            }),
+        );
+
+        out.push_str(&self.render_grouped("Réussite IBAN par recette", |f| {
+            f.recipe.clone().unwrap_or_else(|| "-".to_string())
+        }));
+
+        out.push_str(&self.render_holder_mismatches());
+        out.push_str(&self.render_engines());
+        out.push_str(&self.render_durations());
+
+        out
+    }
+
+    /// Taux de réussite ventilé : c'est ce qui transforme un chiffre global en
+    /// diagnostic exploitable.
+    fn render_grouped(&self, title: &str, key: fn(&FileReport) -> String) -> String {
+        let mut groups: BTreeMap<String, Tally> = BTreeMap::new();
+
+        for file in self.files.iter().filter(|f| !f.known_failure) {
+            groups.entry(key(file)).or_default().add(file.iban);
+        }
+
+        if groups.len() <= 1 {
+            return String::new();
+        }
+
+        let mut out = format!("\n{}\n", title);
+        for (group, tally) in groups {
+            out.push_str(&tally.render(&group));
+        }
+
+        out
+    }
+
+    /// Comment le titulaire est faux, quand il l'est. Chaque catégorie appelle un
+    /// correctif différent — d'où l'intérêt de les compter séparément.
+    fn render_holder_mismatches(&self) -> String {
+        let mut kinds: BTreeMap<&str, usize> = BTreeMap::new();
+
+        for file in &self.files {
+            if let Some(kind) = file.holder_mismatch {
+                *kinds.entry(kind.as_str()).or_insert(0) += 1;
+            }
+        }
+
+        if kinds.is_empty() {
+            return String::new();
+        }
+
+        let mut out = String::from("\nNature des titulaires faux\n");
+        for (kind, count) in kinds {
+            out.push_str(&format!("  {:<16} {:>3}\n", kind, count));
+        }
+
+        out
+    }
+
+    /// Quelles branches du pipeline produisent réellement les succès : les absentes
+    /// sont des candidates à la suppression.
+    fn render_engines(&self) -> String {
+        let mut engines: BTreeMap<&str, usize> = BTreeMap::new();
+
+        for file in &self.files {
+            *engines.entry(file.engine.unwrap_or("aucune")).or_insert(0) += 1;
+        }
+
+        let mut out = String::from("\nStratégie ayant abouti\n");
+        for (engine, count) in engines {
+            out.push_str(&format!("  {:<16} {:>3}\n", engine, count));
+        }
+
+        let second_pass = self.files.iter().filter(|f| f.second_pass).count();
+        out.push_str(&format!("  {:<16} {:>3}\n", "(2e passe)", second_pass));
+
+        out
+    }
+
+    fn render_durations(&self) -> String {
+        let mut durations: Vec<u64> = self.files.iter().map(|f| f.duration_ms).collect();
+
+        if durations.is_empty() {
+            return String::new();
+        }
+
+        durations.sort_unstable();
+
+        let median = durations[durations.len() / 2];
+        let p95 = durations[(durations.len() * 95 / 100).min(durations.len() - 1)];
+        let total: u64 = durations.iter().sum();
+
+        let sum = |f: fn(&FileReport) -> u64| self.files.iter().map(f).sum::<u64>();
+        let (ocrs, tess, pre, pop) = (
+            sum(|f| f.ocrs_ms),
+            sum(|f| f.tess_ms),
+            sum(|f| f.preprocess_ms),
+            sum(|f| f.poppler_ms),
+        );
+        let calls_ocrs: u32 = self.files.iter().map(|f| f.ocrs_calls).sum();
+        let calls_tess: u32 = self.files.iter().map(|f| f.tess_calls).sum();
+        let pct = |ms: u64| {
+            if total == 0 {
+                0.0
+            } else {
+                100.0 * ms as f32 / total as f32
+            }
+        };
+
+        format!(
+            "\nDurées\n  médiane {} ms · p95 {} ms · total {:.1} s\n\
+             \n  Ventilation du temps\n\
+             \x20 ocrs          {:>7.1} s  ({:>4.1} %)  {:>4} appels\n\
+             \x20 tesseract     {:>7.1} s  ({:>4.1} %)  {:>4} appels\n\
+             \x20 prétraitement {:>7.1} s  ({:>4.1} %)\n\
+             \x20 poppler       {:>7.1} s  ({:>4.1} %)\n",
+            median,
+            p95,
+            total as f32 / 1000.0,
+            ocrs as f32 / 1000.0,
+            pct(ocrs),
+            calls_ocrs,
+            tess as f32 / 1000.0,
+            pct(tess),
+            calls_tess,
+            pre as f32 / 1000.0,
+            pct(pre),
+            pop as f32 / 1000.0,
+            pct(pop),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(file: &str) -> FileReport {
+        FileReport {
+            file: file.to_string(),
+            iban: Verdict::Ok,
+            bic: Verdict::Ok,
+            holder_strict: Verdict::Ko,
+            holder_loose: Verdict::Ok,
+            holder_content: Verdict::Ok,
+            known_failure: false,
+            src: Some("pdf_img".to_string()),
+            recipe: Some("h20".to_string()),
+            route: Some("pdf_image"),
+            engine: Some("ocrs:page"),
+            anchor: Some("ocrs"),
+            anchor_height: Some(21),
+            angle_deg: Some(-0.4),
+            second_pass: false,
+            postal_anchors: 0,
+            holder_candidates: 0,
+            holder_blocks_read: 0,
+            width: 1240,
+            height: 1754,
+            duration_ms: 870,
+            ocrs_ms: 0,
+            ocrs_calls: 0,
+            tess_ms: 0,
+            tess_calls: 0,
+            preprocess_ms: 0,
+            poppler_ms: 0,
+            failure: None,
+            text_stats: None,
+            holder_mismatch: None,
+        }
+    }
+
+    #[test]
+    fn rates_ignore_fields_without_truth() {
+        let mut without_truth = report("b.pdf");
+        without_truth.iban = Verdict::NoTruth;
+
+        let rendered = Report {
+            files: vec![report("a.pdf"), without_truth],
+            confusion: Confusion::default(),
+        }
+        .render_summary();
+
+        // un seul IBAN mesurable sur les deux documents
+        assert!(rendered.contains("IBAN               1/1"), "{}", rendered);
+    }
+
+    /// Écarter un candidat erroné sans trouver le bon laisse le taux inchangé : seul le
+    /// décompte des valeurs fausses rend le progrès visible.
+    #[test]
+    fn wrong_values_are_counted_apart_from_the_rate() {
+        let mut wrong = report("b.pdf");
+        wrong.bic = Verdict::Ko;
+
+        let mut missing = report("c.pdf");
+        missing.bic = Verdict::NotFound;
+
+        let with_wrong = Report {
+            files: vec![wrong],
+            confusion: Confusion::default(),
+        }
+        .render_summary();
+
+        let with_missing = Report {
+            files: vec![missing],
+            confusion: Confusion::default(),
+        }
+        .render_summary();
+
+        // même taux des deux côtés, mais un seul signale une valeur fausse
+        let bic_line = |rendered: &str| {
+            rendered
+                .lines()
+                .find(|line| line.trim_start().starts_with("BIC"))
+                .unwrap()
+                .to_string()
+        };
+
+        let (wrong_line, missing_line) = (bic_line(&with_wrong), bic_line(&with_missing));
+
+        assert!(wrong_line.contains("0/1"), "{}", wrong_line);
+        assert!(missing_line.contains("0/1"), "{}", missing_line);
+        assert!(wrong_line.contains("dont 1 faux"), "{}", wrong_line);
+        assert!(!missing_line.contains("faux"), "{}", missing_line);
+    }
+
+    #[test]
+    fn known_failures_stay_visible_but_out_of_the_rate() {
+        let mut known = report("c.pdf");
+        known.known_failure = true;
+        known.iban = Verdict::NotFound;
+
+        let rendered = Report {
+            files: vec![report("a.pdf"), known],
+            confusion: Confusion::default(),
+        }
+        .render_summary();
+
+        assert!(rendered.contains("IBAN               1/1"), "{}", rendered);
+        assert!(rendered.contains("1 cas d'échec connu"), "{}", rendered);
+    }
+
+    #[test]
+    fn confusion_pairs_and_positions_are_never_joined() {
+        let mut confusion = Confusion::default();
+        confusion.observe("FR7630001000644919009562088", "FR763O001000644919009562088");
+        confusion.observe("FR7630001000644919009562088", "FR763O001000644919009562088");
+
+        let rendered = confusion.render();
+
+        assert!(rendered.contains("0 -> O"));
+        assert!(rendered.contains("Positions d'erreur"));
+
+        // la position n'apparaît jamais sur la même ligne qu'un caractère
+        for line in rendered.lines().filter(|l| l.contains("->")) {
+            assert!(
+                !line.contains('5'),
+                "position et caractère joints : {}",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn confusion_skips_unalignable_lengths() {
+        let mut confusion = Confusion::default();
+        confusion.observe("FR7630001", "FR76300");
+
+        assert!(confusion.pairs.is_empty());
+        assert!(confusion.render().contains("longueur différente"));
+    }
+
+    /// Le rendu par document ne doit contenir que des étiquettes et des nombres.
+    #[test]
+    fn file_lines_carry_no_recognised_text() {
+        let rendered = Report {
+            files: vec![report("a.pdf")],
+            confusion: Confusion::default(),
+        }
+        .render_files();
+
+        assert!(rendered.contains("a.pdf"));
+        assert!(rendered.contains("ocrs:page"));
+        assert!(!rendered.contains("FR76"));
+    }
+}

--- a/src/bench/truth.rs
+++ b/src/bench/truth.rs
@@ -1,0 +1,518 @@
+//! Vérité terrain d'un corpus, et comparaison avec ce que le pipeline a produit.
+//!
+//! Le fichier reste sur le poste qui héberge le corpus. Rien de ce qu'il contient ne
+//! ressort du banc : il n'alimente que des verdicts.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use crate::rib::normalize_iban;
+
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct Truth {
+    pub iban: Option<String>,
+    pub bic: Option<String>,
+    pub holder: Option<String>,
+    /// Cas dont on sait qu'ils échouent : comptabilisés à part, pour rester visibles
+    /// sans peser sur le taux de réussite.
+    pub known_failure: bool,
+    pub src: Option<String>,
+    pub recipe: Option<String>,
+}
+
+/// Nature d'un écart sur le titulaire, sans son contenu.
+///
+/// « Faux » ne dit pas comment : un bloc tronqué, un bloc débordant sur la
+/// domiciliation, une civilité mal lue et une adresse déformée appellent des correctifs
+/// différents. Ces catégories se déduisent de la seule comparaison des formes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HolderMismatch {
+    /// Moins de lignes que prévu : bloc coupé.
+    Truncated,
+    /// Plus de lignes que prévu : bloc débordant sur autre chose.
+    Overflowing,
+    /// Même nombre de lignes, première ligne (le nom) juste, le reste différent.
+    AddressOnly,
+    /// Même nombre de lignes, première ligne différente d'un ou deux caractères.
+    NameNearMiss,
+    /// Même nombre de lignes, première ligne sans rapport.
+    NameWrong,
+}
+
+impl HolderMismatch {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HolderMismatch::Truncated => "tronqué",
+            HolderMismatch::Overflowing => "débordant",
+            HolderMismatch::AddressOnly => "adresse",
+            HolderMismatch::NameNearMiss => "nom ±1",
+            HolderMismatch::NameWrong => "nom faux",
+        }
+    }
+}
+
+/// Distance de Levenshtein, sur les caractères.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+
+    for (i, ca) in a.iter().enumerate() {
+        let mut cur = vec![i + 1];
+        for (j, cb) in b.iter().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            cur.push((prev[j] + cost).min(prev[j + 1] + 1).min(cur[j] + 1));
+        }
+        prev = cur;
+    }
+
+    prev[b.len()]
+}
+
+/// Catégorise l'écart entre titulaire attendu et trouvé, en comparaison souple.
+pub fn classify_holder_mismatch(expected: &str, found: &str) -> HolderMismatch {
+    let expected: Vec<String> = expected
+        .lines()
+        .map(normalize_holder_loose)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let found: Vec<String> = found
+        .lines()
+        .map(normalize_holder_loose)
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    if found.len() < expected.len() {
+        return HolderMismatch::Truncated;
+    }
+    if found.len() > expected.len() {
+        return HolderMismatch::Overflowing;
+    }
+
+    let (Some(e0), Some(f0)) = (expected.first(), found.first()) else {
+        return HolderMismatch::NameWrong;
+    };
+
+    if e0 == f0 {
+        return HolderMismatch::AddressOnly;
+    }
+
+    if edit_distance(e0, f0) <= 2 {
+        HolderMismatch::NameNearMiss
+    } else {
+        HolderMismatch::NameWrong
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Attendu et trouvé, identiques.
+    Ok,
+    /// Attendu et trouvé, mais différents.
+    Ko,
+    /// Attendu, rien trouvé.
+    NotFound,
+    /// Rien d'attendu : hors du calcul des taux.
+    NoTruth,
+}
+
+impl Verdict {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Verdict::Ok => "OK",
+            Verdict::Ko => "KO",
+            Verdict::NotFound => "--",
+            Verdict::NoTruth => "?",
+        }
+    }
+
+    /// Seuls les cas où une vérité est renseignée entrent dans le taux.
+    pub fn counts(&self) -> bool {
+        !matches!(self, Verdict::NoTruth)
+    }
+
+    pub fn is_ok(&self) -> bool {
+        matches!(self, Verdict::Ok)
+    }
+}
+
+fn strip_accents(text: &str) -> String {
+    text.chars()
+        .map(|c| match c {
+            'é' | 'è' | 'ê' | 'ë' | 'É' | 'È' | 'Ê' | 'Ë' => 'E',
+            'à' | 'â' | 'ä' | 'À' | 'Â' | 'Ä' => 'A',
+            'î' | 'ï' | 'Î' | 'Ï' => 'I',
+            'ô' | 'ö' | 'Ô' | 'Ö' => 'O',
+            'ù' | 'û' | 'ü' | 'Ù' | 'Û' | 'Ü' => 'U',
+            'ç' | 'Ç' => 'C',
+            c => c,
+        })
+        .collect()
+}
+
+pub fn normalize_bic(bic: &str) -> String {
+    bic.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_uppercase())
+        .collect()
+}
+
+/// Comparaison stricte du titulaire : lignes conservées, espaces de bord retirés.
+pub fn normalize_holder_strict(holder: &str) -> String {
+    holder
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<&str>>()
+        .join("\n")
+}
+
+/// Comparaison souple : casse, accents, ponctuation et découpage en lignes ignorés.
+/// Un titulaire correctement lu mais autrement découpé reste un succès.
+pub fn normalize_holder_loose(holder: &str) -> String {
+    strip_accents(holder)
+        .to_uppercase()
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join(" ")
+}
+
+/// Comparaison par contenu : tous les espaces retirés. Un titulaire lu
+/// « 44800STHERBLAIN » porte la même information que « 44800 ST HERBLAIN » — un moteur
+/// qui colle les mots n'a pas mal lu, il a mal segmenté. Les deux verdicts sont rendus :
+/// celui-ci dit si le contenu est là, le souple dit si le rendu est exploitable tel quel.
+pub fn normalize_holder_content(holder: &str) -> String {
+    normalize_holder_loose(holder).replace(' ', "")
+}
+
+fn compare(
+    expected: Option<&String>,
+    found: Option<String>,
+    normalize: fn(&str) -> String,
+) -> Verdict {
+    match (expected, found) {
+        (None, _) => Verdict::NoTruth,
+        (Some(expected), _) if expected.trim().is_empty() => Verdict::NoTruth,
+        (Some(_), None) => Verdict::NotFound,
+        (Some(expected), Some(found)) => {
+            if normalize(expected) == normalize(&found) {
+                Verdict::Ok
+            } else {
+                Verdict::Ko
+            }
+        }
+    }
+}
+
+impl Truth {
+    pub fn iban_verdict(&self, found: Option<&str>) -> Verdict {
+        compare(
+            self.iban.as_ref(),
+            found.map(|s| s.to_string()),
+            normalize_iban,
+        )
+    }
+
+    pub fn bic_verdict(&self, found: Option<&str>) -> Verdict {
+        compare(
+            self.bic.as_ref(),
+            found.map(|s| s.to_string()),
+            normalize_bic,
+        )
+    }
+
+    pub fn holder_strict_verdict(&self, found: Option<&str>) -> Verdict {
+        compare(
+            self.holder.as_ref(),
+            found.map(|s| s.to_string()),
+            normalize_holder_strict,
+        )
+    }
+
+    pub fn holder_loose_verdict(&self, found: Option<&str>) -> Verdict {
+        compare(
+            self.holder.as_ref(),
+            found.map(|s| s.to_string()),
+            normalize_holder_loose,
+        )
+    }
+
+    pub fn holder_content_verdict(&self, found: Option<&str>) -> Verdict {
+        compare(
+            self.holder.as_ref(),
+            found.map(|s| s.to_string()),
+            normalize_holder_content,
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct TruthSet(HashMap<String, Truth>);
+
+impl TruthSet {
+    /// Format : `file;iban;bic;account_holder[;src;recipe;expect]`, les lignes du
+    /// titulaire séparées par `|`. Les colonnes sont repérées par leur nom, donc leur
+    /// ordre est libre et les trois dernières facultatives.
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let content = fs::read_to_string(path)
+            .map_err(|e| format!("lecture de {} : {}", path.display(), e))?;
+
+        let mut lines = content.lines();
+
+        let header: Vec<&str> = lines
+            .next()
+            .ok_or_else(|| format!("{} est vide", path.display()))?
+            .split(';')
+            .map(|field| field.trim())
+            .collect();
+
+        let column = |name: &str| header.iter().position(|field| *field == name);
+
+        let file_column = column("file")
+            .ok_or_else(|| format!("{} n'a pas de colonne `file`", path.display()))?;
+
+        let (iban_column, bic_column) = (column("iban"), column("bic"));
+        let (holder_column, expect_column) = (column("account_holder"), column("expect"));
+        let (src_column, recipe_column) = (column("src"), column("recipe"));
+
+        let mut entries = HashMap::new();
+
+        for line in lines.filter(|line| !line.trim().is_empty()) {
+            let fields: Vec<&str> = line.split(';').collect();
+
+            let Some(file) = fields.get(file_column) else {
+                continue;
+            };
+
+            let text = |index: Option<usize>| {
+                index
+                    .and_then(|i| fields.get(i))
+                    .map(|value| value.trim())
+                    .filter(|value| !value.is_empty())
+                    .map(|value| value.to_string())
+            };
+
+            entries.insert(
+                file.trim().to_string(),
+                Truth {
+                    iban: text(iban_column),
+                    bic: text(bic_column),
+                    holder: text(holder_column).map(|value| value.replace('|', "\n")),
+                    known_failure: text(expect_column).as_deref() == Some("known_failure"),
+                    src: text(src_column),
+                    recipe: text(recipe_column),
+                },
+            );
+        }
+
+        Ok(TruthSet(entries))
+    }
+
+    pub fn get(&self, file: &str) -> Option<&Truth> {
+        self.0.get(file)
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&String, &Truth)> {
+        self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn truth() -> Truth {
+        Truth {
+            iban: Some("FR7630001000644919009562088".to_string()),
+            bic: Some("SOGEFRPP".to_string()),
+            holder: Some("M MATISSE HENRI\n51 RUE BERNARD ROY".to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn iban_comparison_ignores_grouping() {
+        assert_eq!(
+            truth().iban_verdict(Some("FR76 3000 1000 6449 1900 9562 088")),
+            Verdict::Ok
+        );
+        assert_eq!(
+            truth().iban_verdict(Some("FR7630001000644919009562087")),
+            Verdict::Ko
+        );
+        assert_eq!(truth().iban_verdict(None), Verdict::NotFound);
+    }
+
+    /// La fixture `rib_bourso` attend un BIC espacé : la comparaison doit l'accepter.
+    #[test]
+    fn bic_comparison_ignores_spacing() {
+        let truth = Truth {
+            bic: Some("BOUSFRPPXXX".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(truth.bic_verdict(Some("BOUS FRPP XXX")), Verdict::Ok);
+    }
+
+    #[test]
+    fn holder_mismatches_are_categorised_by_shape() {
+        let expected = "M MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES";
+
+        assert_eq!(
+            classify_holder_mismatch(expected, "M MATISSE HENRI"),
+            HolderMismatch::Truncated
+        );
+        assert_eq!(
+            classify_holder_mismatch(
+                expected,
+                "M MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES\nDOMICILIATION"
+            ),
+            HolderMismatch::Overflowing
+        );
+        assert_eq!(
+            classify_holder_mismatch(
+                expected,
+                "M MATISSE HENRI\n51 RUE BERNARD R0Y\n44100 NANTES"
+            ),
+            HolderMismatch::AddressOnly
+        );
+        assert_eq!(
+            classify_holder_mismatch(expected, "M MATISSE HENR\n51 RUE BERNARD ROY\n44100 NANTES"),
+            HolderMismatch::NameNearMiss
+        );
+        assert_eq!(
+            classify_holder_mismatch(
+                expected,
+                "AGENCE DE NANTES\n51 RUE BERNARD ROY\n44100 NANTES"
+            ),
+            HolderMismatch::NameWrong
+        );
+    }
+
+    #[test]
+    fn edit_distance_counts_single_edits() {
+        assert_eq!(edit_distance("HENRI", "HENR"), 1);
+        assert_eq!(edit_distance("VICTOR", "VIGTOR"), 1);
+        assert_eq!(edit_distance("SUZANNE", "SIIZANNE"), 2);
+        assert_eq!(edit_distance("MATISSE", "AGENCE"), 5);
+    }
+
+    #[test]
+    fn loose_holder_tolerates_case_accents_and_line_breaks() {
+        let truth = truth();
+
+        assert_eq!(
+            truth.holder_strict_verdict(Some("M MATISSE HENRI 51 RUE BERNARD ROY")),
+            Verdict::Ko
+        );
+        assert_eq!(
+            truth.holder_loose_verdict(Some("m matisse henri 51 rue bernard roy")),
+            Verdict::Ok
+        );
+        assert_eq!(
+            truth.holder_loose_verdict(Some("M MATISSE HENRI")),
+            Verdict::Ko
+        );
+    }
+
+    /// Les RIB intercalent souvent une ligne vide entre le nom et l'adresse. Elle est
+    /// ignorée de part et d'autre : inutile de la représenter dans la vérité terrain.
+    #[test]
+    fn blank_lines_are_ignored_on_both_sides() {
+        let truth = Truth {
+            holder: Some(
+                "Prenom1 Nom1 ou Prenom2 Nom2\n234 Rue des exemples\n44300 Nantes".to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let with_blank = "Prenom1 Nom1 ou Prenom2 Nom2\n\n234 Rue des exemples\n44300 Nantes";
+
+        assert_eq!(truth.holder_strict_verdict(Some(with_blank)), Verdict::Ok);
+        assert_eq!(truth.holder_loose_verdict(Some(with_blank)), Verdict::Ok);
+    }
+
+    /// Les mots collés par un moteur ne sont pas une erreur de lecture.
+    #[test]
+    fn glued_words_still_match_by_content() {
+        let truth = Truth {
+            holder: Some("M MATISSE HENRI\n51 RUE BERNARD ROY\n44100 NANTES".to_string()),
+            ..Default::default()
+        };
+        let glued = "M MATISSE HENRI\n51RUE BERNARD ROY\n44100NANTES";
+
+        assert_eq!(truth.holder_loose_verdict(Some(glued)), Verdict::Ko);
+        assert_eq!(truth.holder_content_verdict(Some(glued)), Verdict::Ok);
+
+        // un vrai écart reste un écart
+        assert_eq!(
+            truth.holder_content_verdict(Some("M MATISSE HENR\n51 RUE BERNARD ROY\n44100 NANTES")),
+            Verdict::Ko
+        );
+    }
+
+    /// Sans vérité renseignée, le champ sort du calcul du taux plutôt que de compter
+    /// comme un échec.
+    #[test]
+    fn missing_truth_is_excluded_from_scoring() {
+        let empty = Truth::default();
+
+        assert_eq!(empty.iban_verdict(Some("FR76...")), Verdict::NoTruth);
+        assert!(!Verdict::NoTruth.counts());
+        assert!(Verdict::NotFound.counts());
+    }
+
+    #[test]
+    fn loads_a_csv_with_optional_columns() {
+        let dir = std::env::temp_dir().join("la_taupe_truth_test");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("truth.csv");
+
+        fs::write(
+            &path,
+            "file;iban;bic;account_holder;src;recipe;expect\n\
+             a.pdf;FR7630001000644919009562088;SOGEFRPP;M MATISSE|44100 NANTES;pdf_text;natif;ok\n\
+             b.pdf;;;;pdf_img;h20;known_failure\n",
+        )
+        .unwrap();
+
+        let set = TruthSet::load(&path).unwrap();
+
+        assert_eq!(set.len(), 2);
+
+        let a = set.get("a.pdf").unwrap();
+        assert_eq!(a.holder.as_deref(), Some("M MATISSE\n44100 NANTES"));
+        assert!(!a.known_failure);
+
+        let b = set.get("b.pdf").unwrap();
+        assert_eq!(b.iban, None);
+        assert!(b.known_failure);
+
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn a_csv_without_file_column_is_rejected() {
+        let dir = std::env::temp_dir().join("la_taupe_truth_bad");
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("truth.csv");
+
+        fs::write(&path, "iban;bic\nFR76;SOGEFRPP\n").unwrap();
+
+        assert!(TruthSet::load(&path).is_err());
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src/bin/bench.rs
+++ b/src/bin/bench.rs
@@ -1,0 +1,104 @@
+//! Mesure la reconnaissance de RIB sur un corpus.
+//!
+//!     cargo run --release --features bench --bin bench -- \
+//!       --corpus <dir> [--truth <csv>] [--confusion] [--jobs N]
+//!
+//! Le rapport ne contient aucun texte reconnu : un corpus de documents personnels peut
+//! être mesuré sans que son contenu n'en ressorte.
+
+use std::path::PathBuf;
+use std::process::exit;
+
+use la_taupe::bench::{self, truth::TruthSet};
+
+fn value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|arg| arg == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.contains(&String::from("--help")) || args.len() == 1 {
+        println!("Mesure la reconnaissance de RIB sur un corpus.");
+        println!();
+        println!("  --corpus <dir>   dossier des documents (obligatoire)");
+        println!("  --truth <csv>    vérité terrain, <corpus>/truth.csv par défaut");
+        println!("  --confusion      ajoute la matrice de confusion caractère agrégée");
+        println!("  --profile        ajoute le profil de forme du texte reconnu, par verdict");
+        println!("  --jobs <n>       documents traités de front, 4 par défaut");
+        println!("  --bootstrap      écrit une vérité terrain amorcée sur stdout,");
+        println!("                   en ne retenant que les IBAN validant mod-97 et clé RIB");
+        println!("  --check          contrôle la forme de la vérité terrain sans rien mesurer");
+        println!();
+        println!("Le rapport ne contient ni IBAN, ni nom, ni texte reconnu.");
+        exit(0);
+    }
+
+    let Some(corpus) = value(&args, "--corpus").map(PathBuf::from) else {
+        eprintln!("--corpus est obligatoire");
+        exit(1);
+    };
+
+    let jobs = value(&args, "--jobs")
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(4);
+
+    if args.contains(&String::from("--bootstrap")) {
+        match bench::bootstrap(&corpus, jobs) {
+            Ok(csv) => print!("{}", csv),
+            Err(e) => {
+                eprintln!("{}", e);
+                exit(1);
+            }
+        }
+        return;
+    }
+
+    let truth_path = value(&args, "--truth")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| corpus.join("truth.csv"));
+
+    let truths = match TruthSet::load(&truth_path) {
+        Ok(truths) => truths,
+        Err(e) => {
+            eprintln!("{}", e);
+            eprintln!("Amorcer un fichier avec --bootstrap, puis le corriger à la main.");
+            exit(1);
+        }
+    };
+
+    if truths.is_empty() {
+        eprintln!("{} ne contient aucune ligne", truth_path.display());
+        exit(1);
+    }
+
+    if args.contains(&String::from("--check")) {
+        let checks = bench::check::check(&corpus, &truths);
+        print!("{}", bench::check::render(&checks));
+        return;
+    }
+
+    let with_confusion = args.contains(&String::from("--confusion"));
+
+    match bench::run(&corpus, &truths, with_confusion, jobs) {
+        Ok(report) => {
+            print!("{}", report.render_files());
+            print!("{}", report.render_summary());
+
+            if with_confusion && !report.confusion.is_empty() {
+                print!("{}", report.confusion.render());
+            }
+
+            if args.contains(&String::from("--profile")) {
+                print!("{}", report.render_profiles());
+            }
+        }
+        Err(e) => {
+            eprintln!("{}", e);
+            exit(1);
+        }
+    }
+}

--- a/src/bin/synth.rs
+++ b/src/bin/synth.rs
@@ -1,0 +1,50 @@
+//! Génère un corpus de RIB synthétiques et sa vérité terrain.
+//!
+//!     cargo run --release --features bench --bin synth -- --out <dir> [--seed N] [--count N]
+
+use std::path::PathBuf;
+use std::process::exit;
+
+use la_taupe::synth;
+
+fn value(args: &[String], flag: &str) -> Option<String> {
+    args.iter()
+        .position(|arg| arg == flag)
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.contains(&String::from("--help")) || args.len() == 1 {
+        println!("Génère un corpus de RIB synthétiques et sa vérité terrain.");
+        println!();
+        println!("  --out <dir>    dossier de destination (obligatoire)");
+        println!("  --seed <n>     graine du tirage, 1 par défaut");
+        println!("  --count <n>    limite le nombre de documents produits");
+        println!();
+        println!("Les documents sont fictifs : les IBAN sont structurellement valides");
+        println!("mais tirés au hasard, et ne désignent aucun compte réel.");
+        exit(0);
+    }
+
+    let Some(out) = value(&args, "--out").map(PathBuf::from) else {
+        eprintln!("--out est obligatoire");
+        exit(1);
+    };
+
+    let seed = value(&args, "--seed")
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(1);
+
+    let count = value(&args, "--count").and_then(|s| s.parse::<usize>().ok());
+
+    match synth::write(&out, seed, count) {
+        Ok(written) => println!("{} documents écrits dans {}", written, out.display()),
+        Err(e) => {
+            eprintln!("échec de l'écriture du corpus : {}", e);
+            exit(1);
+        }
+    }
+}

--- a/src/file_utils.rs
+++ b/src/file_utils.rs
@@ -21,6 +21,10 @@ pub fn bytes_to_img(bytes: Vec<u8>) -> Result<DynamicImage, String> {
 }
 
 pub fn pdf_bytes_to_string(bytes: Vec<u8>) -> String {
+    crate::timing::measure(crate::timing::poppler, || pdf_bytes_to_string_inner(bytes))
+}
+
+fn pdf_bytes_to_string_inner(bytes: Vec<u8>) -> String {
     let mut child = Command::new("pdftotext")
         .args(["-layout", "-", "-"])
         .stdin(Stdio::piped())
@@ -39,6 +43,10 @@ pub fn pdf_bytes_to_string(bytes: Vec<u8>) -> String {
 }
 
 pub fn pdf_to_img_bytes(file: Vec<u8>) -> Vec<u8> {
+    crate::timing::measure(crate::timing::poppler, || pdf_to_img_bytes_inner(file))
+}
+
+fn pdf_to_img_bytes_inner(file: Vec<u8>) -> Vec<u8> {
     let mut child = Command::new("pdftoppm")
         .args(["-png", "-singlefile"])
         .stdin(Stdio::piped())

--- a/src/image_utils.rs
+++ b/src/image_utils.rs
@@ -19,6 +19,10 @@ const GREEN: Rgb<u8> = Rgb::<u8>([0, 255, 0]);
 const BLACK: Rgb<u8> = Rgb::<u8>([0, 0, 0]);
 
 pub fn only_rotate(image: &DynamicImage, name: &str) -> DynamicImage {
+    crate::timing::measure(crate::timing::preprocess, || only_rotate_inner(image, name))
+}
+
+fn only_rotate_inner(image: &DynamicImage, name: &str) -> DynamicImage {
     let whithout_shadow_image = remove_shadows(image, name);
     let angle = angle(&whithout_shadow_image, name);
 
@@ -26,6 +30,10 @@ pub fn only_rotate(image: &DynamicImage, name: &str) -> DynamicImage {
 }
 
 pub fn clean_image(image: &DynamicImage, name: &str) -> DynamicImage {
+    crate::timing::measure(crate::timing::preprocess, || clean_image_inner(image, name))
+}
+
+fn clean_image_inner(image: &DynamicImage, name: &str) -> DynamicImage {
     let whithout_shadow_image = remove_shadows(image, name);
     let angle = angle(&whithout_shadow_image, name);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "bench")]
+pub mod bench;
 pub mod analysis;
 pub mod datamatrix;
 pub mod fi_extract;
@@ -9,6 +11,9 @@ pub mod ocrs;
 pub mod provenance;
 pub mod rib;
 pub mod shapes;
+#[cfg(feature = "bench")]
+pub mod synth;
 pub mod tesseract;
 pub mod text;
+pub mod timing;
 pub mod twoddoc;

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 use crate::{
     image_utils::{clean_image, only_rotate, resize, rotate, rotate_rect, save_image_in_debug},
     ocrs::{extract_anchors, image_to_string_using_ocrs, ocrs_anchors},
-    provenance::{AnchorSource, Engine, Provenance},
+    provenance::{AnchorSource, Engine, Provenance, TextStats},
     rib::{extract_fr_bic, extract_iban, Rib},
     shapes::{Anchor, Point},
     tesseract::{img_to_string_using_tesseract, tess_analyze},
@@ -53,6 +53,11 @@ pub fn zoom_and_extract(
 
     let (ocrs_text, text_lines, maybe_anchors) = ocrs_anchors(img, &iban_regex, None);
     let maybe_anchor = maybe_anchors.first();
+
+    // empreinte de forme du texte de la première passe : des comptes, jamais le texte
+    if provenance.page_text_stats.is_none() {
+        provenance.page_text_stats = Some(TextStats::of(&ocrs_text));
+    }
 
     if let Some(anchor) = maybe_anchor {
         provenance.anchor = Some(AnchorSource::Ocrs);

--- a/src/ocrs.rs
+++ b/src/ocrs.rs
@@ -38,6 +38,10 @@ fn engine() -> &'static OcrEngine {
 
 /// Détecte les mots, les groupe en lignes et les reconnaît.
 pub fn recognize(img: &DynamicImage) -> Vec<TextLine> {
+    crate::timing::measure(crate::timing::ocrs, || recognize_inner(img))
+}
+
+fn recognize_inner(img: &DynamicImage) -> Vec<TextLine> {
     let img = img.clone().into_rgb8();
     let engine = engine();
 

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -74,9 +74,33 @@ impl Engine {
     }
 }
 
+/// Ce qu'on retient du texte reconnu : des comptes, jamais des caractères.
+///
+/// Sert à comparer la nature des défaillances entre un corpus synthétique et un corpus
+/// réel qu'on ne peut pas lire — quand seuls les taux se comparent, on corrige des
+/// défauts qui n'existent que dans le corpus généré.
+#[derive(Debug, Default, Clone, PartialEq)]
+pub struct TextStats {
+    pub lines: u32,
+    pub words: u32,
+    pub chars: u32,
+    pub digits: u32,
+    pub alphas: u32,
+    pub symbols: u32,
+    pub short_lines: u32,
+    pub single_char_words: u32,
+    pub mixed_words: u32,
+    pub vocabulary_hits: u32,
+    pub has_iban_prefix: bool,
+    pub has_postal_code: bool,
+}
+
 #[derive(Debug, Default, Clone, PartialEq)]
 pub struct Provenance {
     pub route: Option<Route>,
+    /// Statistiques de forme du texte reconnu sur la page, première passe. Un observateur
+    /// facultatif les calcule à la volée : le texte lui-même n'est jamais conservé.
+    pub page_text_stats: Option<TextStats>,
     pub anchor: Option<AnchorSource>,
     /// Hauteur de l'ancre en pixels : c'est la grandeur qui décide si le texte est
     /// assez grand pour être reconnu.
@@ -88,11 +112,105 @@ pub struct Provenance {
     pub second_pass: bool,
     pub image_width: u32,
     pub image_height: u32,
+    /// Ventilation du temps par étape, relevée en fin d'analyse.
+    pub timings: crate::timing::Timings,
     /// Codes postaux détectés sur la page, candidats retenus après tri, blocs lus.
     /// Trois comptes qui disent où la recherche du titulaire s'arrête.
     pub postal_anchors: u32,
     pub holder_candidates: u32,
     pub holder_blocks_read: u32,
+}
+
+impl TextStats {
+    /// Comptages de forme. Les termes cherchés sont ceux dont dépend l'ancrage du
+    /// titulaire et la distinction titulaire/domiciliation.
+    pub fn of(text: &str) -> Self {
+        const VOCABULARY: [&str; 12] = [
+            "IBAN",
+            "BIC",
+            "TITULAIRE",
+            "INTITULE",
+            "COMPTE",
+            "BANQUE",
+            "GUICHET",
+            "DOMICILIATION",
+            "RELEVE",
+            "IDENTITE",
+            "AGENCE",
+            "CLE",
+        ];
+
+        fn fold(c: char) -> char {
+            match c {
+                'é' | 'è' | 'ê' | 'ë' => 'E',
+                'à' | 'â' | 'ä' => 'A',
+                'î' | 'ï' => 'I',
+                'ô' | 'ö' => 'O',
+                'ù' | 'û' | 'ü' => 'U',
+                'ç' => 'C',
+                c => c.to_ascii_uppercase(),
+            }
+        }
+
+        let upper: String = text.chars().map(fold).collect();
+        let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+        let words: Vec<&str> = text.split_whitespace().collect();
+        let chars: Vec<char> = text.chars().filter(|c| !c.is_whitespace()).collect();
+
+        let count = |f: fn(&char) -> bool| chars.iter().filter(|c| f(c)).count() as u32;
+
+        let is_iban_like = |w: &str| {
+            let w = w.to_ascii_uppercase();
+            let b = w.as_bytes();
+            (b.len() >= 4 && &b[..2] == b"FR" && b[2].is_ascii_digit() && b[3].is_ascii_digit())
+                || (b.len() >= 6
+                    && b[..4].iter().all(|c| c.is_ascii_uppercase())
+                    && &b[4..6] == b"FR")
+        };
+
+        let mixed_words = words
+            .iter()
+            .filter(|w| w.chars().count() >= 3 && !is_iban_like(w))
+            .filter(|w| {
+                w.chars().any(|c| c.is_ascii_digit()) && w.chars().any(|c| c.is_alphabetic())
+            })
+            .count() as u32;
+
+        let has_iban_prefix = upper
+            .as_bytes()
+            .windows(4)
+            .any(|w| &w[..2] == b"FR" && w[2].is_ascii_digit() && w[3].is_ascii_digit());
+
+        // cinq chiffres, un blanc, puis au moins deux lettres
+        let has_postal_code = upper
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .windows(2)
+            .any(|pair| {
+                pair[0].len() == 5
+                    && pair[0].bytes().all(|b| b.is_ascii_digit())
+                    && pair[1].chars().take(2).all(|c| c.is_ascii_uppercase())
+                    && pair[1].len() >= 2
+            });
+
+        TextStats {
+            lines: lines.len() as u32,
+            words: words.len() as u32,
+            chars: chars.len() as u32,
+            digits: count(|c| c.is_ascii_digit()),
+            alphas: count(|c| c.is_alphabetic()),
+            symbols: count(|c| !c.is_alphanumeric()),
+            short_lines: lines
+                .iter()
+                .filter(|l| l.trim().chars().count() < 3)
+                .count() as u32,
+            single_char_words: words.iter().filter(|w| w.chars().count() == 1).count() as u32,
+            mixed_words,
+            vocabulary_hits: VOCABULARY.iter().filter(|t| upper.contains(*t)).count() as u32,
+            has_iban_prefix,
+            has_postal_code,
+        }
+    }
 }
 
 impl Provenance {

--- a/src/synth/data.rs
+++ b/src/synth/data.rs
@@ -1,0 +1,265 @@
+//! Données fictives d'un RIB de synthèse.
+//!
+//! Les IBAN produits sont structurellement valides (mod-97 et clé RIB) mais tirés au
+//! hasard : ils ne désignent aucun compte réel. Les titulaires reprennent la convention
+//! des fixtures existantes (peintres), pour qu'un RIB synthétique reste identifiable
+//! comme tel au premier coup d'œil.
+
+use crate::rib::{iban_from_bban, rib_key};
+
+use super::rng::Rng;
+
+/// Codes banque et raisons sociales réels, issus du fichier RIAD de la BCE : c'est la
+/// même source que `IbanToBankName`, donc `bank_name` résout sur les IBAN générés.
+const RIAD_CSV: &str = include_str!("../riad_bank_name.csv");
+
+const BICS: [&str; 11] = [
+    "BDFEFRPPCCT",
+    "PSSTFRPPNTE",
+    "BOUSFRPPXXX",
+    "CEPAFRPP444",
+    "AGRIFRPP847",
+    "CMCIFR2A",
+    "CMBRFR2BXXX",
+    "FTNOFRP1XXX",
+    "CRLYFRPP",
+    "SOGEFRPP",
+    "GPBAFRPPXXX",
+];
+
+const CIVILITIES: [&str; 8] = ["M", "MR", "MME", "MLLE", "MLE", "ML", "Monsieur", "Madame"];
+
+const FIRST_NAMES: [&str; 10] = [
+    "HENRI", "FRIDA", "CAMILLE", "PAUL", "BERTHE", "VINCENT", "SUZANNE", "GUSTAVE", "ROSA", "EDGAR",
+];
+
+const LAST_NAMES: [&str; 10] = [
+    "MATISSE", "KAHLO", "CLAUDEL", "CEZANNE", "MORISOT", "VAN GOGH", "VALADON", "COURBET",
+    "BONHEUR", "DEGAS",
+];
+
+const COMPANY_FORMS: [&str; 6] = ["SAS", "SARL", "SCI", "EURL", "ASSOCIATION", "SA"];
+
+const STREETS: [&str; 10] = [
+    "RUE BERNARD ROY",
+    "AVENUE JULES RENARD",
+    "RUE DES GRIVES",
+    "CHEMIN DU PETIT BOIS",
+    "ALLEE DES SALICAIRES",
+    "RUE VICTOR FORTUN",
+    "RUE EDOUARD TRAVIES",
+    "RUE MARYSE BASTIE",
+    "ALLEE DES ROSES",
+    "RUE DE L HERONNIERE",
+];
+
+const CITIES: [(&str, &str); 8] = [
+    ("44100", "NANTES"),
+    ("44800", "ST HERBLAIN"),
+    ("44240", "LA CHAPELLE SUR ERDRE"),
+    ("44400", "REZE"),
+    ("44640", "LE PELLERIN"),
+    ("44230", "ST SEBASTIEN SUR LOIRE"),
+    ("92120", "MONTROUGE"),
+    ("44000", "NANTES"),
+];
+
+pub struct Bank {
+    pub code: String,
+    pub name: String,
+    pub bic: String,
+}
+
+/// Un RIB de synthèse et sa vérité terrain.
+pub struct RibData {
+    pub bank: Bank,
+    pub branch: String,
+    pub account: String,
+    pub rib_key: String,
+    pub iban: String,
+    /// Lignes du titulaire, dans l'ordre : c'est exactement ce que le pipeline doit
+    /// retrouver, joint par des sauts de ligne.
+    pub holder_lines: Vec<String>,
+    /// Adresse de l'agence : leurre délibéré, le pipeline ne doit pas la confondre
+    /// avec celle du titulaire.
+    pub branch_lines: Vec<String>,
+}
+
+impl RibData {
+    pub fn holder(&self) -> String {
+        self.holder_lines.join("\n")
+    }
+
+    /// Le bloc « Code banque / Code guichet / N° compte / Clé RIB » du tableau, qui
+    /// redit le BBAN de l'IBAN.
+    pub fn bban(&self) -> String {
+        format!(
+            "{}{}{}{}",
+            self.bank.code, self.branch, self.account, self.rib_key
+        )
+    }
+}
+
+fn banks() -> Vec<(String, String)> {
+    RIAD_CSV
+        .lines()
+        .filter_map(|line| {
+            let mut fields = line.split('\t');
+            let riad = fields.next()?;
+            let name = fields.next()?;
+
+            // le code RIAD est le code pays suivi des 5 chiffres du code banque
+            riad.strip_prefix("FR")
+                .filter(|code| code.len() == 5 && code.chars().all(|c| c.is_ascii_digit()))
+                .map(|code| (code.to_string(), name.to_string()))
+        })
+        .collect()
+}
+
+fn address(rng: &mut Rng) -> Vec<String> {
+    let (postal_code, city) = rng.pick(&CITIES);
+
+    vec![
+        format!("{} {}", rng.int(1, 250), rng.pick(&STREETS)),
+        format!("{} {}", postal_code, city),
+    ]
+}
+
+/// Titulaire : personne seule, couple joint par « OU », ou personne morale.
+fn holder(rng: &mut Rng) -> Vec<String> {
+    let mut lines = if rng.chance(0.15) {
+        vec![format!(
+            "{} {} {}",
+            rng.pick(&COMPANY_FORMS),
+            rng.pick(&FIRST_NAMES),
+            rng.pick(&LAST_NAMES)
+        )]
+    } else if rng.chance(0.3) {
+        // couple : parfois sur une ligne, parfois coupé au milieu comme sur les vrais RIB
+        let first = format!(
+            "{} {} {}",
+            rng.pick(&CIVILITIES),
+            rng.pick(&LAST_NAMES),
+            rng.pick(&FIRST_NAMES)
+        );
+        let second = format!(
+            "OU {} {} {}",
+            rng.pick(&CIVILITIES),
+            rng.pick(&LAST_NAMES),
+            rng.pick(&FIRST_NAMES)
+        );
+
+        if rng.chance(0.5) {
+            vec![format!("{} {}", first, second)]
+        } else {
+            vec![first, second]
+        }
+    } else {
+        vec![format!(
+            "{} {} {}",
+            rng.pick(&CIVILITIES),
+            rng.pick(&LAST_NAMES),
+            rng.pick(&FIRST_NAMES)
+        )]
+    };
+
+    // la plupart des RIB portent l'adresse du titulaire, mais pas tous
+    if rng.chance(0.8) {
+        lines.extend(address(rng));
+    }
+
+    lines
+}
+
+/// Numéro de compte : 11 caractères, parfois alphanumériques comme chez certaines
+/// banques — ce qui exerce la table de conversion des lettres de la clé RIB.
+fn account_number(rng: &mut Rng) -> String {
+    if rng.chance(0.2) {
+        let mut account = rng.digits(10);
+        account.push(char::from(b'A' + rng.below(26) as u8));
+        account
+    } else {
+        rng.digits(11)
+    }
+}
+
+pub fn generate(rng: &mut Rng) -> RibData {
+    let banks = banks();
+    let (code, name) = rng.pick(&banks).clone();
+
+    let branch = rng.digits(5);
+    let account = account_number(rng);
+
+    let key = rib_key(&code, &branch, &account).expect("composants de BBAN valides");
+    let rib_key = format!("{:02}", key);
+
+    let bban = format!("{}{}{}{}", code, branch, account, rib_key);
+    let iban = iban_from_bban(&bban).expect("BBAN de 23 caractères");
+
+    let mut branch_lines = vec![format!("AGENCE DE {}", rng.pick(&CITIES).1)];
+    branch_lines.extend(address(rng));
+
+    RibData {
+        bank: Bank {
+            code,
+            name,
+            bic: rng.pick(&BICS).to_string(),
+        },
+        branch,
+        account,
+        rib_key,
+        iban,
+        holder_lines: holder(rng),
+        branch_lines,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fi_extract::IbanToBankName;
+    use crate::rib::check_rib_key;
+    use iban::Iban;
+
+    #[test]
+    fn generated_ibans_are_structurally_valid() {
+        let mut rng = Rng::new(1);
+
+        for _ in 0..200 {
+            let data = generate(&mut rng);
+
+            assert!(
+                data.iban.parse::<Iban>().is_ok(),
+                "mod-97 invalide : {}",
+                data.iban
+            );
+            assert!(
+                check_rib_key(&data.iban),
+                "clé RIB invalide : {}",
+                data.iban
+            );
+
+            // le tableau RIB et l'IBAN portent bien la même information
+            assert_eq!(data.iban[4..], data.bban());
+        }
+    }
+
+    #[test]
+    fn generated_bank_codes_resolve_to_a_name() {
+        let mut rng = Rng::new(2);
+        let names = IbanToBankName::new();
+
+        for _ in 0..50 {
+            let data = generate(&mut rng);
+            assert!(names.bank_name(&data.iban).is_some());
+        }
+    }
+
+    #[test]
+    fn generation_is_reproducible() {
+        let first = generate(&mut Rng::new(99)).iban;
+        let second = generate(&mut Rng::new(99)).iban;
+
+        assert_eq!(first, second);
+    }
+}

--- a/src/synth/degrade.rs
+++ b/src/synth/degrade.rs
@@ -1,0 +1,378 @@
+//! Dégradations contrôlées d'un RIB rasterisé.
+//!
+//! Chaque paramètre est explicite et figure dans le nom du fichier produit, si bien que
+//! le banc ne rend pas un taux global mais des courbes : à quelle hauteur de capitale,
+//! à quel angle, à quel niveau de bruit la reconnaissance cède.
+
+use std::io::{Cursor, Write};
+use std::process::{Command, Stdio};
+
+use image::{codecs::jpeg::JpegEncoder, DynamicImage, ImageBuffer, Luma, Rgb};
+use imageproc::geometric_transformations::{warp_into, Interpolation, Projection};
+
+use crate::image_utils::rotate;
+
+use super::rng::Rng;
+
+/// Hauteur de capitale, en points typographiques, de la ligne d'IBAN des gabarits.
+/// Sert à convertir une hauteur cible en pixels vers une résolution de rastérisation.
+const IBAN_CAP_HEIGHT_PT: f32 = 11.0 * 0.72;
+
+/// Résolution donnant la hauteur de capitale demandée sur la ligne d'IBAN.
+///
+/// À titre de repère, la valeur par défaut de `pdftoppm` (150 dpi) ne produit qu'une
+/// vingtaine de pixels de haut.
+pub fn dpi_for_cap_height(cap_height_px: u32) -> u32 {
+    (cap_height_px as f32 * 72.0 / IBAN_CAP_HEIGHT_PT).round() as u32
+}
+
+/// Rasterise la page demandée d'un PDF à une résolution donnée.
+pub fn rasterize(pdf: &[u8], dpi: u32, page: u32) -> DynamicImage {
+    let mut child = Command::new("pdftoppm")
+        .args([
+            "-png",
+            "-r",
+            &dpi.to_string(),
+            "-f",
+            &page.to_string(),
+            "-l",
+            &page.to_string(),
+            "-singlefile",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("pdftoppm est requis pour générer le corpus");
+
+    let mut stdin = child.stdin.take().expect("stdin de pdftoppm");
+    let owned = pdf.to_vec();
+    std::thread::spawn(move || {
+        let _ = stdin.write_all(&owned);
+    });
+
+    let output = child.wait_with_output().expect("pdftoppm");
+
+    image::load_from_memory(&output.stdout).expect("PNG produit par pdftoppm")
+}
+
+/// Recette de dégradation. Le `Default` est le document propre, tel que scanné à plat.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Degradation {
+    /// Hauteur de capitale visée sur la ligne d'IBAN, en pixels.
+    pub cap_height: u32,
+    /// Quarts de tour horaires, comme une photo prise appareil tourné. Distinct de
+    /// `rotation_deg` : sans perte, et non détectable par la mesure d'inclinaison.
+    pub quarter_turns: u8,
+    pub rotation_deg: f32,
+    /// Amplitude du basculement, en fraction de la largeur. 0 = document à plat.
+    pub perspective: f32,
+    pub blur_sigma: f32,
+    /// Écart-type du bruit, en niveaux sur 255.
+    pub noise: f32,
+    /// Amplitude de l'éclairage inégal, de 0 (uniforme) à 1.
+    pub illumination: f32,
+    /// Document posé sur un support visible plutôt que détouré.
+    pub background: bool,
+    pub jpeg_quality: Option<u8>,
+}
+
+impl Default for Degradation {
+    fn default() -> Self {
+        Degradation {
+            cap_height: 30,
+            quarter_turns: 0,
+            rotation_deg: 0.0,
+            perspective: 0.0,
+            blur_sigma: 0.0,
+            noise: 0.0,
+            illumination: 0.0,
+            background: false,
+            jpeg_quality: None,
+        }
+    }
+}
+
+impl Degradation {
+    /// Nom de recette, repris dans le nom de fichier : c'est ce qui permet de croiser
+    /// un échec avec le paramètre qui l'a provoqué.
+    pub fn recipe(&self) -> String {
+        let mut parts = vec![format!("h{}", self.cap_height)];
+
+        if self.quarter_turns % 4 != 0 {
+            parts.push(format!("turn{}", 90 * (self.quarter_turns % 4) as u16));
+        }
+        if self.rotation_deg != 0.0 {
+            parts.push(format!("rot{}", (self.rotation_deg * 10.0).round() as i32));
+        }
+        if self.perspective > 0.0 {
+            parts.push(format!(
+                "persp{}",
+                (self.perspective * 100.0).round() as i32
+            ));
+        }
+        if self.blur_sigma > 0.0 {
+            parts.push(format!("blur{}", (self.blur_sigma * 10.0).round() as i32));
+        }
+        if self.noise > 0.0 {
+            parts.push(format!("noise{}", self.noise.round() as i32));
+        }
+        if self.illumination > 0.0 {
+            parts.push(format!(
+                "illum{}",
+                (self.illumination * 100.0).round() as i32
+            ));
+        }
+        if self.background {
+            parts.push("bg".to_string());
+        }
+        if let Some(quality) = self.jpeg_quality {
+            parts.push(format!("q{}", quality));
+        }
+
+        parts.join("_")
+    }
+
+    /// Vrai pour les recettes qui imitent une photo prise au téléphone.
+    pub fn is_photo(&self) -> bool {
+        self.background || self.perspective > 0.0
+    }
+}
+
+/// Recadre sur la zone imprimée, avec une marge. Une photo cadre le document, là où un
+/// scan conserve la page entière et ses blancs.
+fn crop_to_content(img: &DynamicImage, margin_ratio: f32) -> DynamicImage {
+    let gray = img.to_luma8();
+    let (mut min_x, mut min_y, mut max_x, mut max_y) = (u32::MAX, u32::MAX, 0u32, 0u32);
+
+    for (x, y, pixel) in gray.enumerate_pixels() {
+        if pixel.0[0] < 240 {
+            min_x = min_x.min(x);
+            min_y = min_y.min(y);
+            max_x = max_x.max(x);
+            max_y = max_y.max(y);
+        }
+    }
+
+    if min_x > max_x || min_y > max_y {
+        return img.clone();
+    }
+
+    let margin = ((max_x - min_x) as f32 * margin_ratio) as u32;
+
+    let x = min_x.saturating_sub(margin);
+    let y = min_y.saturating_sub(margin);
+    let width = (max_x + margin).min(img.width() - 1) - x + 1;
+    let height = (max_y + margin).min(img.height() - 1) - y + 1;
+
+    img.crop_imm(x, y, width, height)
+}
+
+/// Bascule le document comme s'il était photographié de biais.
+fn apply_perspective(img: &DynamicImage, strength: f32, rng: &mut Rng) -> DynamicImage {
+    let image = img.to_rgb8();
+    let (width, height) = (image.width() as f32, image.height() as f32);
+
+    let shift = strength * width;
+    let jitter = |rng: &mut Rng| rng.float(0.35, 1.0) * shift;
+
+    let (top_left, top_right, bottom_right, bottom_left) = (
+        (jitter(rng), jitter(rng)),
+        (width - jitter(rng), jitter(rng)),
+        (width - jitter(rng), height - jitter(rng)),
+        (jitter(rng), height - jitter(rng)),
+    );
+
+    let projection = Projection::from_control_points(
+        [(0.0, 0.0), (width, 0.0), (width, height), (0.0, height)],
+        [top_left, top_right, bottom_right, bottom_left],
+    );
+
+    let Some(projection) = projection else {
+        return img.clone();
+    };
+
+    let mut out = ImageBuffer::from_pixel(image.width(), image.height(), Rgb([255, 255, 255]));
+    warp_into(
+        &image,
+        &projection,
+        Interpolation::Bicubic,
+        Rgb([255, 255, 255]),
+        &mut out,
+    );
+
+    out.into()
+}
+
+/// Pose le document sur un support visible : c'est ce qui distingue une photo d'un
+/// scan, et ce que la détection d'angle par transformée de Hough accroche à tort.
+fn add_background(img: &DynamicImage, rng: &mut Rng) -> DynamicImage {
+    let image = img.to_rgb8();
+    let margin_x = (image.width() as f32 * rng.float(0.06, 0.16)) as u32;
+    let margin_y = (image.height() as f32 * rng.float(0.04, 0.12)) as u32;
+
+    let base = rng.int(70, 140) as u8;
+    let mut canvas = ImageBuffer::from_fn(
+        image.width() + 2 * margin_x,
+        image.height() + 2 * margin_y,
+        |x, y| {
+            // texture grossière du support, pour ne pas offrir un fond parfaitement uni
+            let grain = ((x / 7 + y / 5) % 11) as i32 - 5;
+            let level = (base as i32 + grain).clamp(0, 255) as u8;
+            Rgb([level, level, (level as u16 * 97 / 100) as u8])
+        },
+    );
+
+    image::imageops::overlay(&mut canvas, &image, margin_x as i64, margin_y as i64);
+
+    canvas.into()
+}
+
+/// Éclairage inégal : dégradé directionnel doublé d'une ombre portée.
+fn apply_illumination(img: &DynamicImage, strength: f32, rng: &mut Rng) -> DynamicImage {
+    let image = img.to_luma8();
+    let (width, height) = (image.width() as f32, image.height() as f32);
+
+    let (dir_x, dir_y) = (rng.float(-1.0, 1.0), rng.float(-1.0, 1.0));
+    let (shadow_x, shadow_y) = (rng.float(0.0, width), rng.float(0.0, height));
+    let shadow_radius = width.max(height) * rng.float(0.18, 0.42);
+
+    let out = ImageBuffer::from_fn(image.width(), image.height(), |x, y| {
+        let (fx, fy) = (x as f32 / width - 0.5, y as f32 / height - 0.5);
+
+        let mut gain = 1.0 - strength * 0.55 * (fx * dir_x + fy * dir_y + 0.5);
+
+        let distance = ((x as f32 - shadow_x).powi(2) + (y as f32 - shadow_y).powi(2)).sqrt();
+        if distance < shadow_radius {
+            gain *= 1.0 - strength * 0.45 * (1.0 - distance / shadow_radius);
+        }
+
+        let value = image.get_pixel(x, y).0[0] as f32 * gain;
+
+        Luma([value.clamp(0.0, 255.0) as u8])
+    });
+
+    DynamicImage::ImageLuma8(out)
+}
+
+fn add_noise(img: &DynamicImage, sigma: f32, rng: &mut Rng) -> DynamicImage {
+    let image = img.to_luma8();
+
+    // somme de deux tirages uniformes : approximation suffisante d'un bruit gaussien
+    let out = ImageBuffer::from_fn(image.width(), image.height(), |x, y| {
+        let noise = (rng.float(-1.0, 1.0) + rng.float(-1.0, 1.0)) * sigma;
+        let value = image.get_pixel(x, y).0[0] as f32 + noise;
+
+        Luma([value.clamp(0.0, 255.0) as u8])
+    });
+
+    DynamicImage::ImageLuma8(out)
+}
+
+/// Applique une recette complète, dans l'ordre où les défauts apparaissent
+/// physiquement : géométrie, puis support, puis lumière, puis capteur.
+pub fn apply(img: &DynamicImage, degradation: &Degradation, rng: &mut Rng) -> DynamicImage {
+    let mut out = if degradation.is_photo() {
+        crop_to_content(img, 0.04)
+    } else {
+        img.clone()
+    };
+
+    // l'orientation de prise de vue précède tout le reste
+    out = match degradation.quarter_turns % 4 {
+        1 => out.rotate90(),
+        2 => out.rotate180(),
+        3 => out.rotate270(),
+        _ => out,
+    };
+
+    if degradation.perspective > 0.0 {
+        out = apply_perspective(&out, degradation.perspective, rng);
+    }
+
+    if degradation.rotation_deg != 0.0 {
+        out = rotate(&out, degradation.rotation_deg.to_radians());
+    }
+
+    if degradation.background {
+        out = add_background(&out, rng);
+    }
+
+    if degradation.illumination > 0.0 {
+        out = apply_illumination(&out, degradation.illumination, rng);
+    }
+
+    if degradation.blur_sigma > 0.0 {
+        out = DynamicImage::ImageLuma8(imageproc::filter::gaussian_blur_f32(
+            &out.to_luma8(),
+            degradation.blur_sigma,
+        ));
+    }
+
+    if degradation.noise > 0.0 {
+        out = add_noise(&out, degradation.noise, rng);
+    }
+
+    out
+}
+
+/// Encode en JPEG à la qualité demandée.
+pub fn to_jpeg(img: &DynamicImage, quality: u8) -> Vec<u8> {
+    let mut buffer = Cursor::new(Vec::new());
+    let gray = img.to_luma8();
+
+    JpegEncoder::new_with_quality(&mut buffer, quality)
+        .encode_image(&gray)
+        .expect("encodage JPEG");
+
+    buffer.into_inner()
+}
+
+pub fn to_png(img: &DynamicImage) -> Vec<u8> {
+    let mut buffer = Cursor::new(Vec::new());
+
+    img.to_luma8()
+        .write_to(&mut buffer, image::ImageFormat::Png)
+        .expect("encodage PNG");
+
+    buffer.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_pdftoppm_resolution_is_marginal() {
+        // 150 dpi, la valeur par défaut de pdftoppm, ne laisse qu'une vingtaine de
+        // pixels de haut à l'IBAN : c'est la marge dans laquelle le pipeline travaille
+        // aujourd'hui sur les PDF scannés.
+        assert_eq!(dpi_for_cap_height(30), 273);
+        assert_eq!(dpi_for_cap_height(20), 182);
+        assert_eq!(dpi_for_cap_height(10), 91);
+    }
+
+    #[test]
+    fn recipe_names_are_stable_and_readable() {
+        assert_eq!(Degradation::default().recipe(), "h30");
+
+        let photo = Degradation {
+            cap_height: 14,
+            rotation_deg: 3.0,
+            perspective: 0.04,
+            background: true,
+            jpeg_quality: Some(50),
+            ..Default::default()
+        };
+
+        assert_eq!(photo.recipe(), "h14_rot30_persp4_bg_q50");
+
+        let turned = Degradation {
+            quarter_turns: 3,
+            ..Default::default()
+        };
+        assert_eq!(turned.recipe(), "h30_turn270");
+        assert!(photo.is_photo());
+        assert!(!Degradation::default().is_photo());
+    }
+}

--- a/src/synth/layout.rs
+++ b/src/synth/layout.rs
@@ -1,0 +1,583 @@
+//! Gabarits de RIB, calqués sur les mises en page réellement observées dans
+//! `tests/fixtures/rib/*.txt`.
+//!
+//! Chacun place le tableau « Code banque / Guichet / N° de compte / Clé RIB », la ligne
+//! IBAN, le BIC, le bloc titulaire et un bloc de domiciliation. Ce dernier est un leurre
+//! délibéré : il porte lui aussi une adresse avec code postal, et le pipeline ne doit
+//! pas le prendre pour le titulaire.
+
+use super::data::RibData;
+use super::pdf::{Font, Line, Page, Pdf, Text, A4_WIDTH};
+
+pub struct Layout {
+    pub name: &'static str,
+    build: fn(&mut Page, &RibData),
+}
+
+pub const LAYOUTS: [Layout; 7] = [
+    Layout {
+        name: "bp",
+        build: banque_populaire,
+    },
+    Layout {
+        name: "sg",
+        build: societe_generale,
+    },
+    Layout {
+        name: "lcl",
+        build: lcl,
+    },
+    Layout {
+        name: "postale",
+        build: banque_postale,
+    },
+    Layout {
+        name: "entreprise",
+        build: entreprise,
+    },
+    Layout {
+        name: "cic",
+        build: cic,
+    },
+    Layout {
+        name: "cepac",
+        build: caisse_epargne_pac,
+    },
+];
+
+/// `FR7630001…` → `FR76 3000 1000 6449 1900 9562 088`
+pub fn grouped_iban(iban: &str) -> String {
+    iban.chars()
+        .collect::<Vec<char>>()
+        .chunks(4)
+        .map(|chunk| chunk.iter().collect::<String>())
+        .collect::<Vec<String>>()
+        .join(" ")
+}
+
+/// Largeur approchée d'une chaîne : Courier est à chasse fixe, Helvetica est estimée.
+/// Suffisant pour aligner à droite sur un document de test.
+fn text_width(content: &str, size: f32, font: Font) -> f32 {
+    let ratio = match font {
+        Font::Courier | Font::CourierBold => 0.60,
+        Font::Helvetica => 0.50,
+        Font::HelveticaBold => 0.55,
+    };
+
+    content.chars().count() as f32 * size * ratio
+}
+
+fn text(page: &mut Page, x: f32, y: f32, size: f32, font: Font, content: &str) {
+    page.texts.push(Text {
+        x,
+        y,
+        size,
+        font,
+        content: content.to_string(),
+    });
+}
+
+fn right_text(page: &mut Page, right: f32, y: f32, size: f32, font: Font, content: &str) {
+    text(
+        page,
+        right - text_width(content, size, font),
+        y,
+        size,
+        font,
+        content,
+    );
+}
+
+/// Empile des lignes et renvoie l'ordonnée juste sous le bloc.
+fn block(page: &mut Page, x: f32, y: f32, size: f32, font: Font, lines: &[String]) -> f32 {
+    let leading = size * 1.45;
+
+    for (i, line) in lines.iter().enumerate() {
+        text(page, x, y + i as f32 * leading, size, font, line);
+    }
+
+    y + lines.len() as f32 * leading
+}
+
+fn rule(page: &mut Page, x1: f32, y: f32, x2: f32) {
+    page.lines.push(Line {
+        x1,
+        y1: y,
+        x2,
+        y2: y,
+        width: 0.6,
+    });
+}
+
+/// Tableau RIB encadré : quatre colonnes libellées, valeurs dessous.
+fn rib_table(page: &mut Page, y: f32, x: f32, headers: [&str; 4], data: &RibData, boxed: bool) {
+    let columns = [x, x + 105.0, x + 195.0, x + 305.0];
+    let values = [
+        data.bank.code.clone(),
+        data.branch.clone(),
+        data.account.clone(),
+        data.rib_key.clone(),
+    ];
+
+    for (i, header) in headers.iter().enumerate() {
+        text(page, columns[i], y, 8.0, Font::HelveticaBold, header);
+        text(page, columns[i], y + 18.0, 10.0, Font::Courier, &values[i]);
+    }
+
+    if boxed {
+        // les traits de cellule qui frôlent les chiffres sont une source connue
+        // d'erreurs d'OCR : le corpus doit en contenir
+        rule(page, x - 6.0, y - 10.0, x + 380.0);
+        rule(page, x - 6.0, y + 5.0, x + 380.0);
+        rule(page, x - 6.0, y + 24.0, x + 380.0);
+
+        for column in columns.iter().chain([x + 380.0].iter()) {
+            page.lines.push(Line {
+                x1: column - 6.0,
+                y1: y - 10.0,
+                x2: column - 6.0,
+                y2: y + 24.0,
+                width: 0.6,
+            });
+        }
+    }
+}
+
+fn legal_blurb(page: &mut Page, x: f32, y: f32) {
+    let lines = [
+        "Ce relevé est destiné à être remis, sur leur demande,",
+        "à vos créanciers ou débiteurs appelés à faire inscrire",
+        "des opérations à votre compte (virements, paiements de",
+        "quittances, etc.). Son utilisation vous garantit le bon",
+        "enregistrement des opérations en cause.",
+    ];
+
+    for (i, line) in lines.iter().enumerate() {
+        text(page, x, y + i as f32 * 10.0, 6.5, Font::Helvetica, line);
+    }
+}
+
+fn banque_populaire(page: &mut Page, data: &RibData) {
+    text(
+        page,
+        340.0,
+        60.0,
+        8.0,
+        Font::HelveticaBold,
+        "Relevé d'Identité Bancaire / Bank details",
+    );
+    legal_blurb(page, 340.0, 78.0);
+
+    text(
+        page,
+        60.0,
+        95.0,
+        9.0,
+        Font::HelveticaBold,
+        "Titulaire du compte / Account holder",
+    );
+    block(page, 60.0, 120.0, 10.0, Font::Helvetica, &data.holder_lines);
+
+    text(page, 60.0, 210.0, 8.0, Font::HelveticaBold, "IBAN");
+    text(page, 330.0, 210.0, 8.0, Font::HelveticaBold, "BIC");
+    text(
+        page,
+        60.0,
+        228.0,
+        11.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+    text(page, 330.0, 228.0, 11.0, Font::Courier, &data.bank.bic);
+
+    rib_table(
+        page,
+        275.0,
+        60.0,
+        ["Code Banque", "Code guichet", "N° du compte", "Clé RIB"],
+        data,
+        false,
+    );
+
+    text(
+        page,
+        60.0,
+        340.0,
+        8.0,
+        Font::HelveticaBold,
+        "Domiciliation / Paying Bank",
+    );
+    block(page, 60.0, 358.0, 9.0, Font::Helvetica, &data.branch_lines);
+}
+
+/// Titulaire à gauche, agence alignée à droite : c'est cette mise en page qui met en
+/// difficulté un masque de recadrage calé sur un alignement à gauche.
+fn societe_generale(page: &mut Page, data: &RibData) {
+    text(
+        page,
+        170.0,
+        60.0,
+        12.0,
+        Font::HelveticaBold,
+        "RELEVÉ D'IDENTITÉ BANCAIRE / IBAN",
+    );
+
+    text(page, 60.0, 100.0, 9.0, Font::HelveticaBold, "Titulaire");
+    block(page, 60.0, 118.0, 10.0, Font::Helvetica, &data.holder_lines);
+
+    right_text(
+        page,
+        A4_WIDTH - 60.0,
+        100.0,
+        9.0,
+        Font::HelveticaBold,
+        "Agence de domiciliation",
+    );
+    for (i, line) in data.branch_lines.iter().enumerate() {
+        right_text(
+            page,
+            A4_WIDTH - 60.0,
+            118.0 + i as f32 * 14.0,
+            9.0,
+            Font::Helvetica,
+            line,
+        );
+    }
+
+    text(page, 60.0, 215.0, 9.0, Font::HelveticaBold, "RIB");
+    rib_table(
+        page,
+        200.0,
+        150.0,
+        ["Banque", "Guichet", "Compte", "Clé RIB"],
+        data,
+        false,
+    );
+
+    text(page, 60.0, 275.0, 9.0, Font::HelveticaBold, "IBAN");
+    text(
+        page,
+        150.0,
+        275.0,
+        11.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+
+    text(page, 60.0, 300.0, 9.0, Font::HelveticaBold, "BIC");
+    text(page, 150.0, 300.0, 11.0, Font::Courier, &data.bank.bic);
+}
+
+/// Libellé du titulaire sur deux lignes et valeur en retrait, tableau encadré.
+fn lcl(page: &mut Page, data: &RibData) {
+    text(page, 60.0, 70.0, 9.0, Font::HelveticaBold, "TITULAIRE DU");
+    text(page, 60.0, 84.0, 9.0, Font::HelveticaBold, "COMPTE :");
+    block(page, 150.0, 84.0, 10.0, Font::Helvetica, &data.holder_lines);
+
+    text(page, 60.0, 190.0, 9.0, Font::HelveticaBold, "IBAN :");
+    text(
+        page,
+        130.0,
+        190.0,
+        11.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+
+    text(page, 60.0, 215.0, 9.0, Font::HelveticaBold, "BIC :");
+    text(page, 130.0, 215.0, 11.0, Font::Courier, &data.bank.bic);
+
+    rib_table(
+        page,
+        280.0,
+        60.0,
+        ["BANQUE", "INDICATIF", "NUMERO DE COMPTE", "CLEF"],
+        data,
+        true,
+    );
+
+    text(
+        page,
+        60.0,
+        360.0,
+        9.0,
+        Font::HelveticaBold,
+        "DOMICILIATION :",
+    );
+    block(page, 170.0, 360.0, 9.0, Font::Helvetica, &data.branch_lines);
+}
+
+/// Aucun libellé « titulaire » : le bloc d'adresse est seul, ce qui force la détection
+/// à s'appuyer sur la civilité et le code postal.
+fn banque_postale(page: &mut Page, data: &RibData) {
+    text(
+        page,
+        60.0,
+        60.0,
+        11.0,
+        Font::HelveticaBold,
+        "RELEVÉ D'IDENTITÉ BANCAIRE",
+    );
+
+    block(
+        page,
+        330.0,
+        110.0,
+        10.0,
+        Font::Helvetica,
+        &data.holder_lines,
+    );
+
+    rib_table(
+        page,
+        220.0,
+        60.0,
+        ["Établissement", "Guichet", "N° de compte", "Clé"],
+        data,
+        true,
+    );
+
+    text(page, 60.0, 300.0, 8.0, Font::HelveticaBold, "IBAN");
+    text(
+        page,
+        60.0,
+        318.0,
+        11.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+
+    text(page, 330.0, 300.0, 8.0, Font::HelveticaBold, "BIC");
+    text(page, 330.0, 318.0, 11.0, Font::Courier, &data.bank.bic);
+
+    text(page, 60.0, 370.0, 8.0, Font::HelveticaBold, "DOMICILIATION");
+    block(page, 60.0, 388.0, 9.0, Font::Helvetica, &data.branch_lines);
+}
+
+/// Mise en page compacte, titulaire personne morale sans civilité.
+fn entreprise(page: &mut Page, data: &RibData) {
+    text(
+        page,
+        60.0,
+        60.0,
+        10.0,
+        Font::HelveticaBold,
+        "RELEVÉ D'IDENTITÉ BANCAIRE",
+    );
+
+    text(
+        page,
+        60.0,
+        95.0,
+        8.0,
+        Font::HelveticaBold,
+        "Intitulé du compte",
+    );
+    block(page, 60.0, 112.0, 10.0, Font::Helvetica, &data.holder_lines);
+
+    text(page, 60.0, 185.0, 8.0, Font::HelveticaBold, "IBAN");
+    text(
+        page,
+        130.0,
+        185.0,
+        10.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+
+    text(page, 60.0, 205.0, 8.0, Font::HelveticaBold, "BIC");
+    text(page, 130.0, 205.0, 10.0, Font::Courier, &data.bank.bic);
+
+    rib_table(
+        page,
+        245.0,
+        60.0,
+        ["Code banque", "Code guichet", "Numéro de compte", "Clé RIB"],
+        data,
+        true,
+    );
+
+    text(page, 60.0, 320.0, 8.0, Font::HelveticaBold, "Domiciliation");
+    block(page, 60.0, 337.0, 9.0, Font::Helvetica, &data.branch_lines);
+}
+
+/// Domiciliation à gauche avec son propre code postal, titulaire à droite en regard.
+/// Structure observée sur un document réel où le titulaire était tronqué : deux codes
+/// postaux sur la même ligne, et seul le premier — celui de l'agence — était examiné.
+fn cic(page: &mut Page, data: &RibData) {
+    text(page, 250.0, 60.0, 12.0, Font::HelveticaBold, "RIB");
+
+    rib_table(
+        page,
+        95.0,
+        60.0,
+        ["Banque", "Guichet", "N° compte", "Clé"],
+        data,
+        false,
+    );
+    text(page, 460.0, 95.0, 8.0, Font::HelveticaBold, "Domiciliation");
+    text(
+        page,
+        460.0,
+        113.0,
+        9.0,
+        Font::Helvetica,
+        &data.branch_lines[0],
+    );
+
+    text(page, 60.0, 165.0, 9.0, Font::HelveticaBold, "IBAN");
+    text(
+        page,
+        130.0,
+        165.0,
+        11.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+    text(page, 400.0, 165.0, 9.0, Font::HelveticaBold, "BIC");
+    text(page, 440.0, 165.0, 11.0, Font::Courier, &data.bank.bic);
+
+    // les deux blocs adressés, côte à côte, sur les mêmes lignes
+    text(page, 60.0, 220.0, 9.0, Font::HelveticaBold, "Domiciliation");
+    block(page, 60.0, 238.0, 10.0, Font::Helvetica, &data.branch_lines);
+    text(
+        page,
+        60.0,
+        238.0 + 3.0 * 14.5,
+        8.0,
+        Font::Helvetica,
+        "tél 02 40 00 00 00",
+    );
+
+    text(
+        page,
+        320.0,
+        220.0,
+        9.0,
+        Font::HelveticaBold,
+        "Titulaire du compte (Account Owner)",
+    );
+    block(
+        page,
+        320.0,
+        238.0,
+        10.0,
+        Font::Helvetica,
+        &data.holder_lines,
+    );
+}
+
+/// Libellé sur deux lignes, « TITULAIRE DU » puis « COMPTE : », le titulaire commençant
+/// à droite du libellé dès la première ligne, sans adresse. Structure observée sur un
+/// document réel où la première ligne du couple était perdue.
+fn caisse_epargne_pac(page: &mut Page, data: &RibData) {
+    text(
+        page,
+        60.0,
+        60.0,
+        11.0,
+        Font::HelveticaBold,
+        "RELEVÉ D'IDENTITÉ BANCAIRE",
+    );
+
+    text(page, 60.0, 110.0, 9.0, Font::HelveticaBold, "TITULAIRE DU");
+    text(page, 60.0, 124.0, 9.0, Font::HelveticaBold, "COMPTE :");
+
+    // le titulaire seul, sans adresse, en regard des deux lignes du libellé
+    let name_lines: Vec<String> = data
+        .holder_lines
+        .iter()
+        .take_while(|line| !line.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .cloned()
+        .collect();
+    block(page, 150.0, 110.0, 10.0, Font::Helvetica, &name_lines);
+
+    text(page, 60.0, 190.0, 9.0, Font::HelveticaBold, "IBAN");
+    text(
+        page,
+        130.0,
+        190.0,
+        11.0,
+        Font::Courier,
+        &grouped_iban(&data.iban),
+    );
+    text(page, 60.0, 212.0, 9.0, Font::HelveticaBold, "BIC");
+    text(page, 130.0, 212.0, 11.0, Font::Courier, &data.bank.bic);
+
+    rib_table(
+        page,
+        260.0,
+        60.0,
+        ["Code banque", "Code guichet", "N° de compte", "Clé RIB"],
+        data,
+        true,
+    );
+
+    text(page, 60.0, 330.0, 8.0, Font::HelveticaBold, "Domiciliation");
+    block(page, 60.0, 348.0, 9.0, Font::Helvetica, &data.branch_lines);
+}
+
+/// Rend un gabarit en PDF d'une page.
+pub fn render(layout: &Layout, data: &RibData) -> Pdf {
+    let mut page = Page::default();
+    (layout.build)(&mut page, data);
+
+    // en tête plutôt qu'en pied : une mention en bas de page A4 étendrait la boîte
+    // englobante du contenu et neutraliserait le recadrage des variantes photo
+    text(
+        &mut page,
+        60.0,
+        32.0,
+        7.0,
+        Font::Helvetica,
+        "DOCUMENT DE TEST GÉNÉRÉ - DONNÉES FICTIVES",
+    );
+
+    Pdf {
+        pages: vec![page],
+        images: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_utils::pdf_bytes_to_string;
+    use crate::rib::Rib;
+    use crate::synth::data;
+    use crate::synth::rng::Rng;
+
+    #[test]
+    fn grouping_matches_the_usual_presentation() {
+        assert_eq!(
+            grouped_iban("FR7630001000644919009562088"),
+            "FR76 3000 1000 6449 1900 9562 088"
+        );
+    }
+
+    /// Un RIB synthétique non dégradé doit être lu sans effort par le chemin
+    /// `pdftotext`. Si ce test échoue, c'est le gabarit qui est irréaliste, pas le
+    /// pipeline qui est mauvais.
+    #[test]
+    fn every_layout_is_parsed_from_native_pdf() {
+        let mut rng = Rng::new(4);
+
+        for layout in LAYOUTS.iter() {
+            for _ in 0..6 {
+                let data = data::generate(&mut rng);
+                let text = pdf_bytes_to_string(render(layout, &data).render());
+                let parsed = Rib::parse(text);
+
+                let parsed = parsed
+                    .unwrap_or_else(|| panic!("aucun RIB extrait du gabarit {}", layout.name));
+
+                assert_eq!(
+                    parsed.iban(),
+                    grouped_iban(&data.iban),
+                    "IBAN erroné sur le gabarit {}",
+                    layout.name
+                );
+            }
+        }
+    }
+}

--- a/src/synth/mod.rs
+++ b/src/synth/mod.rs
@@ -1,0 +1,307 @@
+//! Génération d'un corpus de RIB synthétiques.
+//!
+//! Le corpus réel étant constitué de documents personnels, le développement des
+//! algorithmes se fait sur des RIB fictifs dégradés de façon contrôlée. Chaque
+//! dégradation étant paramétrée et nommée, le banc ne rend pas un taux global mais des
+//! courbes : à quelle hauteur de capitale, à quel angle, à quel niveau de bruit la
+//! reconnaissance cède.
+
+pub mod data;
+pub mod degrade;
+pub mod layout;
+pub mod package;
+pub mod pdf;
+pub mod rng;
+
+use std::fs;
+use std::path::Path;
+
+use degrade::Degradation;
+use package::{Form, Sample};
+use rng::Rng;
+
+#[derive(Clone)]
+pub struct Scenario {
+    pub form: Form,
+    pub degradation: Degradation,
+}
+
+fn scan(cap_height: u32) -> Degradation {
+    Degradation {
+        cap_height,
+        ..Default::default()
+    }
+}
+
+/// Une photo prise au téléphone porte toujours un support visible et un éclairage
+/// inégal — le document n'y est ni détouré, ni uniformément exposé. Il n'existe pas de
+/// « photo propre » ; en simuler serait se donner des cas qui n'arrivent pas.
+fn photo(cap_height: u32) -> Degradation {
+    Degradation {
+        cap_height,
+        background: true,
+        illumination: 0.4,
+        blur_sigma: 0.5,
+        jpeg_quality: Some(70),
+        ..Default::default()
+    }
+}
+
+/// La grille de conditions à couvrir.
+///
+/// Sa composition suit ce que le service reçoit réellement, établi sur deux corpus :
+/// des photos d'un côté, des PDF produits par les chaînes éditiques bancaires de
+/// l'autre. Les scans y sont marginaux, et ce sont les photos — non les scans — qui
+/// arrivent pivotées.
+///
+/// Les PDF natifs restent peu nombreux malgré leur poids réel : ils sont reconnus sans
+/// OCR, donc toujours à 100 %, et les sur-représenter diluerait les écarts que le banc
+/// doit rendre visibles. Le taux global n'est pas une estimation du taux de production,
+/// c'est un indicateur de régression.
+///
+/// Chaque paramètre est éprouvé séparément, pour qu'un échec s'impute à une cause et
+/// non à un cumul.
+pub fn scenarios() -> Vec<Scenario> {
+    let jpeg = |degradation: Degradation| Scenario {
+        form: Form::Jpeg,
+        degradation,
+    };
+
+    let scanned = |degradation: Degradation| Scenario {
+        form: Form::PdfImg,
+        degradation,
+    };
+
+    vec![
+        // référence : reconnu sans OCR
+        Scenario {
+            form: Form::PdfText,
+            degradation: scan(30),
+        },
+        // photos : résolution, du plus lisible au plus petit texte observé
+        jpeg(photo(45)),
+        jpeg(photo(30)),
+        jpeg(photo(20)),
+        jpeg(photo(14)),
+        // photos pivotées : un quart des photos réelles le sont
+        jpeg(Degradation {
+            quarter_turns: 1,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            quarter_turns: 2,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            quarter_turns: 3,
+            ..photo(20)
+        }),
+        // photos : chaque défaut de prise de vue isolé
+        jpeg(Degradation {
+            rotation_deg: 3.0,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            rotation_deg: 15.0,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            perspective: 0.05,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            blur_sigma: 1.5,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            noise: 12.0,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            illumination: 0.85,
+            ..photo(20)
+        }),
+        jpeg(Degradation {
+            jpeg_quality: Some(40),
+            ..photo(20)
+        }),
+        // photo cumulant les défauts, prise à la va-vite
+        jpeg(Degradation {
+            rotation_deg: 5.0,
+            perspective: 0.06,
+            blur_sigma: 1.2,
+            noise: 10.0,
+            illumination: 0.8,
+            jpeg_quality: Some(45),
+            ..photo(14)
+        }),
+        // Photos sur lesquelles l'OCR ne détecte presque rien : c'est à cela que
+        // ressemblent les échecs réels — une dizaine de caractères lus, aucun libellé,
+        // pas de préfixe d'IBAN — et aucune recette ci-dessus ne le produisait. Le corpus
+        // sous-estimait la part d'images irrécupérables et surestimait celle des
+        // documents lisibles où seul l'IBAN manque.
+        //
+        // Deux recettes seulement : les images irrécupérables sont environ six pour cent
+        // du corpus réel, et en mettre davantage écraserait le taux global sans rien
+        // apprendre de plus.
+        jpeg(Degradation {
+            blur_sigma: 3.5,
+            ..photo(10)
+        }),
+        jpeg(Degradation {
+            perspective: 0.12,
+            rotation_deg: 25.0,
+            blur_sigma: 1.5,
+            ..photo(12)
+        }),
+        // orientation portée par le tag EXIF plutôt que par les pixels
+        Scenario {
+            form: Form::JpegExif,
+            degradation: photo(20),
+        },
+        Scenario {
+            form: Form::Png,
+            degradation: photo(30),
+        },
+        // scans : minoritaires, mais présents
+        scanned(scan(20)),
+        scanned(scan(14)),
+        // conditionnements qui déroutent l'aiguillage de `vec_to_rib`
+        Scenario {
+            form: Form::PdfImgText,
+            degradation: scan(20),
+        },
+        Scenario {
+            form: Form::PdfImgMulti,
+            degradation: scan(20),
+        },
+        Scenario {
+            form: Form::PdfPage2,
+            degradation: scan(20),
+        },
+    ]
+}
+
+/// Le plan du corpus : chaque gabarit décliné sur chaque scénario. Séparé de la
+/// construction, qui rasterise et coûte cher.
+pub fn plan(limit: Option<usize>) -> Vec<(usize, &'static layout::Layout, Scenario)> {
+    let scenarios = scenarios();
+    let total = layout::LAYOUTS.len() * scenarios.len();
+    let wanted = limit.unwrap_or(total).min(total);
+
+    (0..wanted)
+        .map(|index| {
+            (
+                index,
+                &layout::LAYOUTS[index % layout::LAYOUTS.len()],
+                scenarios[index / layout::LAYOUTS.len()].clone(),
+            )
+        })
+        .collect()
+}
+
+/// Produit le corpus. À lancer en `--release` : la rastérisation et les dégradations
+/// sont dix fois plus lentes en profil de développement.
+pub fn generate(seed: u64, limit: Option<usize>) -> Vec<Sample> {
+    let mut rng = Rng::new(seed);
+
+    plan(limit)
+        .into_iter()
+        .map(|(index, layout, scenario)| {
+            let data = data::generate(&mut rng);
+
+            package::build(
+                index,
+                layout,
+                data,
+                scenario.form,
+                &scenario.degradation,
+                &mut rng,
+            )
+        })
+        .collect()
+}
+
+fn csv_field(value: &str) -> String {
+    value.replace(';', ",").replace('\n', "|")
+}
+
+/// Écrit le corpus et sa vérité terrain, et renvoie le nombre d'échantillons produits.
+pub fn write(dir: &Path, seed: u64, limit: Option<usize>) -> std::io::Result<usize> {
+    fs::create_dir_all(dir)?;
+
+    let samples = generate(seed, limit);
+    let mut truth = String::from("file;iban;bic;account_holder;src;recipe;expect\n");
+
+    for sample in &samples {
+        fs::write(dir.join(&sample.name), &sample.bytes)?;
+
+        truth.push_str(&format!(
+            "{};{};{};{};{};{};{}\n",
+            csv_field(&sample.name),
+            sample.data.iban,
+            sample.data.bank.bic,
+            csv_field(&sample.data.holder()),
+            sample.form.tag(),
+            csv_field(&sample.recipe),
+            if sample.form.known_failure() {
+                "known_failure"
+            } else {
+                "ok"
+            }
+        ));
+    }
+
+    fs::write(dir.join("truth.csv"), truth)?;
+
+    Ok(samples.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_grid_covers_every_layout_and_scenario() {
+        let plan = plan(None);
+
+        assert_eq!(plan.len(), layout::LAYOUTS.len() * scenarios().len());
+
+        for scenario in scenarios() {
+            assert!(
+                plan.iter().any(|(_, _, s)| s.form == scenario.form),
+                "forme absente du corpus : {}",
+                scenario.form.tag()
+            );
+        }
+
+        for layout in layout::LAYOUTS.iter() {
+            assert!(
+                plan.iter().any(|(_, l, _)| l.name == layout.name),
+                "gabarit absent du corpus : {}",
+                layout.name
+            );
+        }
+    }
+
+    #[test]
+    fn names_are_unique_and_carry_the_recipe() {
+        let samples = generate(5, Some(6));
+        let mut names: Vec<&str> = samples.iter().map(|s| s.name.as_str()).collect();
+
+        names.sort_unstable();
+        let count = names.len();
+        names.dedup();
+
+        assert_eq!(names.len(), count);
+        assert!(samples.iter().any(|s| s.name.contains("natif")));
+    }
+
+    /// La vérité terrain ne doit jamais casser le format à cause d'un séparateur
+    /// présent dans une donnée.
+    #[test]
+    fn truth_fields_survive_separators() {
+        assert_eq!(csv_field("A;B"), "A,B");
+        assert_eq!(csv_field("ligne1\nligne2"), "ligne1|ligne2");
+    }
+}

--- a/src/synth/package.rs
+++ b/src/synth/package.rs
@@ -1,0 +1,393 @@
+//! Mise en forme finale d'un RIB synthétique.
+//!
+//! C'est le conditionnement, et non le contenu, qui décide de la branche empruntée dans
+//! `analysis::vec_to_rib`. Un même RIB est donc décliné en PDF natif, en PDF scanné et
+//! en photo, y compris dans des variantes dont on sait qu'elles échouent aujourd'hui —
+//! mieux vaut un échec mesuré qu'un angle mort.
+
+use image::DynamicImage;
+
+use super::data::RibData;
+use super::degrade::{self, Degradation};
+use super::layout::{self, Layout};
+use super::pdf::{Font, Jpeg, Page, Pdf, PlacedImage, Text, A4_HEIGHT, A4_WIDTH};
+use super::rng::Rng;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Form {
+    /// PDF vectoriel : `pdftotext` suffit, aucune OCR.
+    PdfText,
+    /// Scan nu : `pdftotext` ne renvoie rien, le pipeline rasterise.
+    PdfImg,
+    /// Scan accompagné de texte parasite sans IBAN : `pdftotext` renvoie du texte
+    /// inexploitable, et c'est le garde-fou `list_img_in_pdf == 1` qui décide.
+    PdfImgText,
+    /// Logo vectorisé en plus du scan, soit deux images : `list_img_in_pdf != 1`.
+    PdfImgMulti,
+    /// Courrier d'accompagnement en page 1, RIB en page 2 : `pdftoppm -singlefile`
+    /// ne rasterise que la première page.
+    PdfPage2,
+    Jpeg,
+    /// JPEG dont l'image est stockée pivotée, redressée par le tag EXIF Orientation.
+    JpegExif,
+    Png,
+}
+
+impl Form {
+    /// Étiquette reportée dans la colonne `src` du rapport.
+    pub fn tag(&self) -> &'static str {
+        match self {
+            Form::PdfText => "pdf_text",
+            Form::PdfImg => "pdf_img",
+            Form::PdfImgText => "pdf_img_text",
+            Form::PdfImgMulti => "pdf_img_multi",
+            Form::PdfPage2 => "pdf_p2",
+            Form::Jpeg => "jpeg",
+            Form::JpegExif => "jpeg_exif",
+            Form::Png => "png",
+        }
+    }
+
+    pub fn extension(&self) -> &'static str {
+        match self {
+            Form::Jpeg | Form::JpegExif => "jpg",
+            Form::Png => "png",
+            _ => "pdf",
+        }
+    }
+
+    /// Formes que le pipeline ne sait pas traiter en l'état. Elles restent dans le
+    /// corpus, mais hors du taux de réussite : ce sont des cibles, pas des régressions.
+    pub fn known_failure(&self) -> bool {
+        matches!(self, Form::PdfImgMulti | Form::PdfPage2)
+    }
+}
+
+pub struct Sample {
+    pub name: String,
+    pub bytes: Vec<u8>,
+    pub form: Form,
+    pub recipe: String,
+    pub data: RibData,
+}
+
+/// Segment APP1 portant le seul tag Orientation.
+fn exif_orientation_segment(orientation: u16) -> Vec<u8> {
+    let mut payload = Vec::new();
+
+    payload.extend_from_slice(b"Exif\0\0");
+    payload.extend_from_slice(b"II\x2a\x00"); // petit-boutiste
+    payload.extend_from_slice(&8u32.to_le_bytes()); // décalage du premier IFD
+    payload.extend_from_slice(&1u16.to_le_bytes()); // une seule entrée
+    payload.extend_from_slice(&0x0112u16.to_le_bytes()); // Orientation
+    payload.extend_from_slice(&3u16.to_le_bytes()); // SHORT
+    payload.extend_from_slice(&1u32.to_le_bytes()); // un élément
+    payload.extend_from_slice(&orientation.to_le_bytes());
+    payload.extend_from_slice(&0u16.to_le_bytes()); // bourrage de la valeur sur 4 octets
+    payload.extend_from_slice(&0u32.to_le_bytes()); // pas d'IFD suivant
+
+    let mut segment = vec![0xFF, 0xE1];
+    segment.extend_from_slice(&((payload.len() + 2) as u16).to_be_bytes());
+    segment.extend_from_slice(&payload);
+
+    segment
+}
+
+/// Insère le segment EXIF juste après le marqueur de début d'image.
+fn with_exif_orientation(jpeg: Vec<u8>, orientation: u16) -> Vec<u8> {
+    let mut out = vec![0xFF, 0xD8];
+    out.extend_from_slice(&exif_orientation_segment(orientation));
+    out.extend_from_slice(&jpeg[2..]);
+
+    out
+}
+
+/// Enveloppe une image dans un PDF, en la cadrant sur la page.
+fn image_page(img: &DynamicImage, quality: u8) -> (Jpeg, PlacedImage) {
+    let bytes = degrade::to_jpeg(img, quality);
+    let (width, height) = (img.width(), img.height());
+
+    let scale = (A4_WIDTH / width as f32).min(A4_HEIGHT / height as f32);
+    let (drawn_width, drawn_height) = (width as f32 * scale, height as f32 * scale);
+
+    (
+        Jpeg {
+            bytes,
+            width,
+            height,
+            grayscale: true,
+        },
+        PlacedImage {
+            index: 0,
+            x: (A4_WIDTH - drawn_width) / 2.0,
+            y: (A4_HEIGHT - drawn_height) / 2.0,
+            width: drawn_width,
+            height: drawn_height,
+        },
+    )
+}
+
+fn note(page: &mut Page, x: f32, y: f32, size: f32, content: &str) {
+    page.texts.push(Text {
+        x,
+        y,
+        size,
+        font: Font::Helvetica,
+        content: content.to_string(),
+    });
+}
+
+/// Petit aplat servant de logo : sa seule raison d'être est de porter le nombre
+/// d'images de la page à deux.
+fn logo() -> Jpeg {
+    let img = DynamicImage::ImageLuma8(image::ImageBuffer::from_fn(64, 64, |x, y| {
+        image::Luma([(((x / 8) + (y / 8)) % 2 * 120 + 60) as u8])
+    }));
+
+    Jpeg {
+        bytes: degrade::to_jpeg(&img, 80),
+        width: 64,
+        height: 64,
+        grayscale: true,
+    }
+}
+
+fn package(form: Form, img: &DynamicImage, quality: u8) -> Vec<u8> {
+    let (jpeg, placed) = image_page(img, quality);
+
+    match form {
+        Form::Jpeg => degrade::to_jpeg(img, quality),
+        Form::JpegExif => with_exif_orientation(degrade::to_jpeg(&img.rotate270(), quality), 6),
+        Form::Png => degrade::to_png(img),
+
+        Form::PdfImg => Pdf {
+            pages: vec![Page {
+                images: vec![placed],
+                ..Default::default()
+            }],
+            images: vec![jpeg],
+        }
+        .render(),
+
+        Form::PdfImgText => {
+            let mut page = Page {
+                images: vec![placed],
+                ..Default::default()
+            };
+            note(
+                &mut page,
+                40.0,
+                30.0,
+                9.0,
+                "Votre releve d'identite bancaire",
+            );
+            note(&mut page, 40.0, A4_HEIGHT - 20.0, 7.0, "Page 1 / 1");
+
+            Pdf {
+                pages: vec![page],
+                images: vec![jpeg],
+            }
+            .render()
+        }
+
+        Form::PdfImgMulti => {
+            let mut page = Page {
+                images: vec![
+                    placed,
+                    PlacedImage {
+                        index: 1,
+                        x: 40.0,
+                        y: 20.0,
+                        width: 48.0,
+                        height: 48.0,
+                    },
+                ],
+                ..Default::default()
+            };
+            note(&mut page, 100.0, 40.0, 9.0, "Votre banque en ligne");
+
+            Pdf {
+                pages: vec![page],
+                images: vec![jpeg, logo()],
+            }
+            .render()
+        }
+
+        Form::PdfPage2 => {
+            let mut cover = Page::default();
+            note(&mut cover, 60.0, 80.0, 11.0, "Madame, Monsieur,");
+            note(
+                &mut cover,
+                60.0,
+                110.0,
+                10.0,
+                "Vous trouverez en page suivante le releve d'identite bancaire",
+            );
+            note(&mut cover, 60.0, 126.0, 10.0, "que vous nous avez demande.");
+
+            Pdf {
+                pages: vec![
+                    cover,
+                    Page {
+                        images: vec![placed],
+                        ..Default::default()
+                    },
+                ],
+                images: vec![jpeg],
+            }
+            .render()
+        }
+
+        Form::PdfText => unreachable!("le PDF natif ne passe pas par une image"),
+    }
+}
+
+/// Décline un RIB en un échantillon d'une forme et d'une recette données.
+pub fn build(
+    index: usize,
+    layout: &Layout,
+    data: RibData,
+    form: Form,
+    degradation: &Degradation,
+    rng: &mut Rng,
+) -> Sample {
+    // Le gabarit sans adresse ne pose que le nom : la vérité terrain doit suivre.
+    let data = if layout.name == "cepac" {
+        RibData {
+            holder_lines: data
+                .holder_lines
+                .iter()
+                .take_while(|line| !line.chars().next().is_some_and(|c| c.is_ascii_digit()))
+                .cloned()
+                .collect(),
+            ..data
+        }
+    } else {
+        data
+    };
+
+    let pdf = layout::render(layout, &data).render();
+
+    let (bytes, recipe) = if form == Form::PdfText {
+        (pdf, "natif".to_string())
+    } else {
+        let raster =
+            degrade::rasterize(&pdf, degrade::dpi_for_cap_height(degradation.cap_height), 1);
+        let degraded = degrade::apply(&raster, degradation, rng);
+        let quality = degradation.jpeg_quality.unwrap_or(92);
+
+        (package(form, &degraded, quality), degradation.recipe())
+    };
+
+    Sample {
+        name: format!(
+            "{:03}_{}_{}_{}.{}",
+            index,
+            layout.name,
+            form.tag(),
+            recipe,
+            form.extension()
+        ),
+        bytes,
+        form,
+        recipe,
+        data,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_utils::{list_img_in_pdf, pdf_bytes_to_string};
+
+    fn sample(form: Form, cap_height: u32) -> Sample {
+        let mut rng = Rng::new(11);
+        let data = crate::synth::data::generate(&mut rng);
+
+        build(
+            0,
+            &layout::LAYOUTS[0],
+            data,
+            form,
+            &Degradation {
+                cap_height,
+                ..Default::default()
+            },
+            &mut rng,
+        )
+    }
+
+    #[test]
+    fn native_pdf_carries_extractable_text() {
+        let sample = sample(Form::PdfText, 30);
+
+        assert_eq!(tree_magic_mini::from_u8(&sample.bytes), "application/pdf");
+        assert!(pdf_bytes_to_string(sample.bytes).contains("FR"));
+    }
+
+    #[test]
+    fn scanned_pdf_carries_no_text_but_one_image() {
+        let sample = sample(Form::PdfImg, 20);
+
+        assert_eq!(tree_magic_mini::from_u8(&sample.bytes), "application/pdf");
+        assert!(pdf_bytes_to_string(sample.bytes.clone()).trim().is_empty());
+        assert_eq!(list_img_in_pdf(sample.bytes), 1);
+    }
+
+    /// La variante qui exerce le garde-fou : du texte, mais pas d'IBAN dedans.
+    #[test]
+    fn scanned_pdf_with_junk_text_still_holds_a_single_image() {
+        let sample = sample(Form::PdfImgText, 20);
+        let text = pdf_bytes_to_string(sample.bytes.clone());
+
+        assert!(!text.trim().is_empty());
+        assert!(!text.contains("FR76"));
+        assert_eq!(list_img_in_pdf(sample.bytes), 1);
+    }
+
+    /// Échec connu : deux images sur la page désarment le garde-fou.
+    #[test]
+    fn multi_image_pdf_defeats_the_single_image_guard() {
+        let sample = sample(Form::PdfImgMulti, 20);
+
+        assert!(Form::PdfImgMulti.known_failure());
+        assert_eq!(list_img_in_pdf(sample.bytes), 2);
+    }
+
+    #[test]
+    fn second_page_pdf_has_two_pages() {
+        let sample = sample(Form::PdfPage2, 20);
+
+        assert!(Form::PdfPage2.known_failure());
+        assert!(pdf_bytes_to_string(sample.bytes).contains("page suivante"));
+    }
+
+    #[test]
+    fn photos_are_plain_images() {
+        assert_eq!(
+            tree_magic_mini::from_u8(&sample(Form::Jpeg, 20).bytes),
+            "image/jpeg"
+        );
+        assert_eq!(
+            tree_magic_mini::from_u8(&sample(Form::Png, 20).bytes),
+            "image/png"
+        );
+    }
+
+    /// L'image est stockée pivotée et redressée par le tag : le pipeline doit honorer
+    /// l'orientation EXIF pour retomber sur ses pieds.
+    #[test]
+    fn exif_variant_is_stored_rotated() {
+        let sample = sample(Form::JpegExif, 20);
+        let plain = self::sample(Form::Jpeg, 20);
+
+        assert_eq!(tree_magic_mini::from_u8(&sample.bytes), "image/jpeg");
+
+        let rotated = image::load_from_memory(&sample.bytes).expect("JPEG lisible");
+        let upright = image::load_from_memory(&plain.bytes).expect("JPEG lisible");
+
+        // sans appliquer l'EXIF, la variante est en paysage là où l'original est en portrait
+        assert_eq!(rotated.width(), upright.height());
+        assert_eq!(rotated.height(), upright.width());
+    }
+}

--- a/src/synth/pdf.rs
+++ b/src/synth/pdf.rs
@@ -1,0 +1,397 @@
+//! Écriture de PDF minimalistes.
+//!
+//! Écrit à la main plutôt que via une bibliothèque : le corpus doit contenir des
+//! formes que les générateurs courants n'exposent pas commodément — page portant deux
+//! images distinctes, document multipage dont seule la seconde page porte le RIB,
+//! image scannée accompagnée de texte parasite. Un PDF de test n'utilise que les
+//! polices de base, donc rien à embarquer.
+
+/// Les 14 polices standard ne nécessitent aucun embarquement.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Font {
+    Helvetica,
+    HelveticaBold,
+    Courier,
+    CourierBold,
+}
+
+impl Font {
+    const ALL: [Font; 4] = [
+        Font::Helvetica,
+        Font::HelveticaBold,
+        Font::Courier,
+        Font::CourierBold,
+    ];
+
+    fn base_name(&self) -> &'static str {
+        match self {
+            Font::Helvetica => "Helvetica",
+            Font::HelveticaBold => "Helvetica-Bold",
+            Font::Courier => "Courier",
+            Font::CourierBold => "Courier-Bold",
+        }
+    }
+
+    fn resource(&self) -> &'static str {
+        match self {
+            Font::Helvetica => "F1",
+            Font::HelveticaBold => "F2",
+            Font::Courier => "F3",
+            Font::CourierBold => "F4",
+        }
+    }
+}
+
+/// Texte positionné, `y` mesuré depuis le haut de la page.
+pub struct Text {
+    pub x: f32,
+    pub y: f32,
+    pub size: f32,
+    pub font: Font,
+    pub content: String,
+}
+
+/// Trait de séparation ou bordure de cellule.
+pub struct Line {
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
+    pub width: f32,
+}
+
+/// Image JPEG placée sur la page, référencée par son index dans `Pdf::images`.
+pub struct PlacedImage {
+    pub index: usize,
+    pub x: f32,
+    pub y: f32,
+    pub width: f32,
+    pub height: f32,
+}
+
+pub struct Jpeg {
+    pub bytes: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub grayscale: bool,
+}
+
+#[derive(Default)]
+pub struct Page {
+    pub texts: Vec<Text>,
+    pub lines: Vec<Line>,
+    pub images: Vec<PlacedImage>,
+}
+
+pub const A4_WIDTH: f32 = 595.0;
+pub const A4_HEIGHT: f32 = 842.0;
+
+#[derive(Default)]
+pub struct Pdf {
+    pub pages: Vec<Page>,
+    pub images: Vec<Jpeg>,
+}
+
+/// Échappement PDF, avec émission des accents en WinAnsi.
+///
+/// Les translittérer serait plus simple, mais fausserait la mesure : les en-têtes du
+/// pipeline sont cherchés sous leur forme accentuée (« Intitulé du compte »), et un
+/// corpus sans accents les rendrait introuvables pour de mauvaises raisons.
+fn escape(text: &str) -> String {
+    let mut out = String::new();
+
+    for c in text.chars() {
+        match c {
+            '\\' => out.push_str(r"\\"),
+            '(' => out.push_str(r"\("),
+            ')' => out.push_str(r"\)"),
+            '\u{2018}' | '\u{2019}' => out.push('\''),
+            '\u{201c}' | '\u{201d}' => out.push('"'),
+            c if c.is_ascii() => out.push(c),
+            // WinAnsiEncoding recouvre Latin-1 sur cette plage
+            c if (c as u32) <= 0xFF => out.push_str(&format!("\\{:03o}", c as u32)),
+            _ => out.push('?'),
+        }
+    }
+
+    out
+}
+
+impl Page {
+    fn content_stream(&self) -> String {
+        let mut out = String::new();
+
+        for image in &self.images {
+            // le système de coordonnées PDF part du bas de la page
+            let y = A4_HEIGHT - image.y - image.height;
+            out.push_str(&format!(
+                "q {:.2} 0 0 {:.2} {:.2} {:.2} cm /Im{} Do Q\n",
+                image.width, image.height, image.x, y, image.index
+            ));
+        }
+
+        for line in &self.lines {
+            out.push_str(&format!(
+                "{:.2} w {:.2} {:.2} m {:.2} {:.2} l S\n",
+                line.width,
+                line.x1,
+                A4_HEIGHT - line.y1,
+                line.x2,
+                A4_HEIGHT - line.y2
+            ));
+        }
+
+        for text in &self.texts {
+            out.push_str(&format!(
+                "BT /{} {:.2} Tf {:.2} {:.2} Td ({}) Tj ET\n",
+                text.font.resource(),
+                text.size,
+                text.x,
+                A4_HEIGHT - text.y,
+                escape(&text.content)
+            ));
+        }
+
+        out
+    }
+}
+
+impl Pdf {
+    pub fn render(&self) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::new();
+        let mut offsets: Vec<usize> = Vec::new();
+
+        out.extend_from_slice(b"%PDF-1.4\n");
+
+        // Numérotation : 1 catalogue, 2 arbre de pages, puis deux objets par page
+        // (page et contenu), puis les polices, puis les images.
+        let page_count = self.pages.len();
+        let first_font = 3 + 2 * page_count;
+        let first_image = first_font + Font::ALL.len();
+
+        let push = |out: &mut Vec<u8>, offsets: &mut Vec<usize>, body: &[u8]| {
+            offsets.push(out.len());
+            out.extend_from_slice(body);
+        };
+
+        let kids: Vec<String> = (0..page_count)
+            .map(|i| format!("{} 0 R", 3 + 2 * i))
+            .collect();
+
+        push(
+            &mut out,
+            &mut offsets,
+            b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+        );
+        push(
+            &mut out,
+            &mut offsets,
+            format!(
+                "2 0 obj\n<< /Type /Pages /Kids [{}] /Count {} >>\nendobj\n",
+                kids.join(" "),
+                page_count
+            )
+            .as_bytes(),
+        );
+
+        let fonts: Vec<String> = Font::ALL
+            .iter()
+            .enumerate()
+            .map(|(i, font)| format!("/{} {} 0 R", font.resource(), first_font + i))
+            .collect();
+
+        for (i, page) in self.pages.iter().enumerate() {
+            let page_id = 3 + 2 * i;
+            let content_id = page_id + 1;
+
+            let xobjects: Vec<String> = page
+                .images
+                .iter()
+                .map(|image| format!("/Im{} {} 0 R", image.index, first_image + image.index))
+                .collect();
+
+            let resources = if xobjects.is_empty() {
+                format!("<< /Font << {} >> >>", fonts.join(" "))
+            } else {
+                format!(
+                    "<< /Font << {} >> /XObject << {} >> >>",
+                    fonts.join(" "),
+                    xobjects.join(" ")
+                )
+            };
+
+            push(
+                &mut out,
+                &mut offsets,
+                format!(
+                    "{} 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {} {}] /Resources {} /Contents {} 0 R >>\nendobj\n",
+                    page_id, A4_WIDTH, A4_HEIGHT, resources, content_id
+                )
+                .as_bytes(),
+            );
+
+            let stream = page.content_stream();
+            push(
+                &mut out,
+                &mut offsets,
+                format!(
+                    "{} 0 obj\n<< /Length {} >>\nstream\n{}endstream\nendobj\n",
+                    content_id,
+                    stream.len(),
+                    stream
+                )
+                .as_bytes(),
+            );
+        }
+
+        for (i, font) in Font::ALL.iter().enumerate() {
+            push(
+                &mut out,
+                &mut offsets,
+                format!(
+                    "{} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /{} /Encoding /WinAnsiEncoding >>\nendobj\n",
+                    first_font + i,
+                    font.base_name()
+                )
+                .as_bytes(),
+            );
+        }
+
+        for (i, image) in self.images.iter().enumerate() {
+            let color_space = if image.grayscale {
+                "/DeviceGray"
+            } else {
+                "/DeviceRGB"
+            };
+
+            offsets.push(out.len());
+            out.extend_from_slice(
+                format!(
+                    "{} 0 obj\n<< /Type /XObject /Subtype /Image /Width {} /Height {} /ColorSpace {} /BitsPerComponent 8 /Filter /DCTDecode /Length {} >>\nstream\n",
+                    first_image + i,
+                    image.width,
+                    image.height,
+                    color_space,
+                    image.bytes.len()
+                )
+                .as_bytes(),
+            );
+            out.extend_from_slice(&image.bytes);
+            out.extend_from_slice(b"\nendstream\nendobj\n");
+        }
+
+        let xref_offset = out.len();
+        let object_count = offsets.len() + 1;
+
+        out.extend_from_slice(format!("xref\n0 {}\n", object_count).as_bytes());
+        out.extend_from_slice(b"0000000000 65535 f \n");
+        for offset in &offsets {
+            out.extend_from_slice(format!("{:010} 00000 n \n", offset).as_bytes());
+        }
+
+        out.extend_from_slice(
+            format!(
+                "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+                object_count, xref_offset
+            )
+            .as_bytes(),
+        );
+
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::file_utils::pdf_bytes_to_string;
+
+    fn page_with(content: &str) -> Pdf {
+        Pdf {
+            pages: vec![Page {
+                texts: vec![Text {
+                    x: 50.0,
+                    y: 100.0,
+                    size: 11.0,
+                    font: Font::Helvetica,
+                    content: content.to_string(),
+                }],
+                ..Default::default()
+            }],
+            images: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn produces_a_pdf_readable_by_poppler() {
+        let bytes = page_with("FR76 3000 1000 6449 1900 9562 088").render();
+
+        assert!(bytes.starts_with(b"%PDF-"));
+        assert!(tree_magic_mini::from_u8(&bytes) == "application/pdf");
+
+        let text = pdf_bytes_to_string(bytes);
+        assert!(
+            text.contains("FR76 3000 1000 6449 1900 9562 088"),
+            "texte extrait : {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn escapes_parentheses_and_backslashes() {
+        let text = pdf_bytes_to_string(page_with(r"SCI (A\B) MATISSE").render());
+
+        assert!(
+            text.contains(r"SCI (A\B) MATISSE"),
+            "texte extrait : {:?}",
+            text
+        );
+    }
+
+    /// Les accents doivent survivre au aller-retour : les en-têtes que cherche le
+    /// pipeline en portent.
+    #[test]
+    fn keeps_accents_through_winansi() {
+        let text = pdf_bytes_to_string(page_with("Intitulé du compte / Vendée").render());
+
+        assert!(
+            text.contains("Intitulé du compte / Vendée"),
+            "texte extrait : {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn multipage_keeps_pages_separate() {
+        let pdf = Pdf {
+            pages: vec![
+                Page {
+                    texts: vec![Text {
+                        x: 50.0,
+                        y: 100.0,
+                        size: 11.0,
+                        font: Font::Helvetica,
+                        content: "PREMIERE PAGE".to_string(),
+                    }],
+                    ..Default::default()
+                },
+                Page {
+                    texts: vec![Text {
+                        x: 50.0,
+                        y: 100.0,
+                        size: 11.0,
+                        font: Font::Helvetica,
+                        content: "SECONDE PAGE".to_string(),
+                    }],
+                    ..Default::default()
+                },
+            ],
+            images: Vec::new(),
+        };
+
+        let text = pdf_bytes_to_string(pdf.render());
+
+        assert!(text.contains("PREMIERE PAGE"));
+        assert!(text.contains("SECONDE PAGE"));
+    }
+}

--- a/src/synth/rng.rs
+++ b/src/synth/rng.rs
@@ -1,0 +1,107 @@
+//! Générateur pseudo-aléatoire déterministe.
+//!
+//! Volontairement maison plutôt que `rand` : le corpus synthétique doit être
+//! reproductible à l'identique d'une version à l'autre, ce qu'un générateur dont
+//! l'implémentation peut changer ne garantit pas.
+
+/// xorshift64*, suffisant pour tirer des variantes de documents.
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        // un état nul resterait bloqué à zéro
+        Rng(seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407)
+            | 1)
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545F4914F6CDD1D)
+    }
+
+    /// Entier dans [0, n).
+    pub fn below(&mut self, n: usize) -> usize {
+        if n == 0 {
+            return 0;
+        }
+        (self.next_u64() % n as u64) as usize
+    }
+
+    /// Entier dans [lo, hi].
+    pub fn int(&mut self, lo: i64, hi: i64) -> i64 {
+        if hi <= lo {
+            return lo;
+        }
+        lo + self.below((hi - lo + 1) as usize) as i64
+    }
+
+    /// Flottant dans [lo, hi).
+    pub fn float(&mut self, lo: f32, hi: f32) -> f32 {
+        let unit = (self.next_u64() >> 40) as f32 / (1u64 << 24) as f32;
+        lo + unit * (hi - lo)
+    }
+
+    pub fn chance(&mut self, probability: f32) -> bool {
+        self.float(0.0, 1.0) < probability
+    }
+
+    pub fn pick<'a, T>(&mut self, items: &'a [T]) -> &'a T {
+        &items[self.below(items.len())]
+    }
+
+    /// Chaîne de `len` chiffres.
+    pub fn digits(&mut self, len: usize) -> String {
+        (0..len)
+            .map(|_| char::from(b'0' + self.below(10) as u8))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_seed_same_sequence() {
+        let mut a = Rng::new(42);
+        let mut b = Rng::new(42);
+        let mut c = Rng::new(43);
+
+        let sa: Vec<u64> = (0..8).map(|_| a.next_u64()).collect();
+        let sb: Vec<u64> = (0..8).map(|_| b.next_u64()).collect();
+        let sc: Vec<u64> = (0..8).map(|_| c.next_u64()).collect();
+
+        assert_eq!(sa, sb);
+        assert_ne!(sa, sc);
+    }
+
+    #[test]
+    fn seed_zero_is_not_degenerate() {
+        let mut rng = Rng::new(0);
+        let drawn: Vec<u64> = (0..4).map(|_| rng.next_u64()).collect();
+
+        assert!(drawn.iter().all(|&x| x != 0));
+    }
+
+    #[test]
+    fn stays_in_bounds() {
+        let mut rng = Rng::new(7);
+
+        for _ in 0..500 {
+            assert!(rng.below(10) < 10);
+            assert!((3..=9).contains(&rng.int(3, 9)));
+            assert_eq!(rng.int(5, 5), 5);
+
+            let f = rng.float(-2.0, 2.0);
+            assert!((-2.0..2.0).contains(&f));
+
+            assert_eq!(rng.digits(6).len(), 6);
+        }
+    }
+}

--- a/src/tesseract.rs
+++ b/src/tesseract.rs
@@ -11,6 +11,12 @@ use scraper::{ElementRef, Html, Selector};
 use crate::shapes::{Anchor, Point};
 
 pub fn img_to_string_using_tesseract(img: DynamicImage) -> String {
+    crate::timing::measure(crate::timing::tesseract, || {
+        img_to_string_using_tesseract_inner(img)
+    })
+}
+
+fn img_to_string_using_tesseract_inner(img: DynamicImage) -> String {
     let img = increase_image_size_if_needed(img);
 
     let mut buffer = Cursor::new(Vec::new());
@@ -45,7 +51,7 @@ pub fn img_to_string_using_tesseract(img: DynamicImage) -> String {
 }
 
 pub fn tess_analyze(img: &DynamicImage) -> (String, Option<f32>, Option<Anchor>) {
-    let (hocr, doc) = image_to_hocr(img);
+    let (hocr, doc) = crate::timing::measure(crate::timing::tesseract, || image_to_hocr(img));
     let (mut angle, mut anchor) = (None, None);
 
     if let Some(el) = iban_el(&doc) {

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,0 +1,61 @@
+//! Compteurs de temps par étape, à l'échelle du thread.
+//!
+//! Le banc dit combien de temps prend un document ; il ne dit pas où. Ces compteurs
+//! ventilent la durée entre les moteurs et le prétraitement — c'est ce qui décide où
+//! porter l'effort de latence.
+
+use std::cell::RefCell;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Timings {
+    /// Reconnaissance ocrs (détection + reconnaissance).
+    pub ocrs: Duration,
+    pub ocrs_calls: u32,
+    /// Sous-processus tesseract, hocr et texte.
+    pub tesseract: Duration,
+    pub tesseract_calls: u32,
+    /// Nettoyage, rotation, redimensionnement.
+    pub preprocess: Duration,
+    /// Rastérisation et extraction de texte des PDF.
+    pub poppler: Duration,
+}
+
+thread_local! {
+    static CURRENT: RefCell<Timings> = RefCell::new(Timings::default());
+}
+
+pub fn reset() {
+    CURRENT.with(|t| *t.borrow_mut() = Timings::default());
+}
+
+pub fn snapshot() -> Timings {
+    CURRENT.with(|t| *t.borrow())
+}
+
+/// Mesure une étape et l'impute à un compteur.
+pub fn measure<T>(bucket: fn(&mut Timings, Duration), f: impl FnOnce() -> T) -> T {
+    let start = Instant::now();
+    let result = f();
+    let elapsed = start.elapsed();
+    CURRENT.with(|t| bucket(&mut t.borrow_mut(), elapsed));
+    result
+}
+
+pub fn ocrs(t: &mut Timings, d: Duration) {
+    t.ocrs += d;
+    t.ocrs_calls += 1;
+}
+
+pub fn tesseract(t: &mut Timings, d: Duration) {
+    t.tesseract += d;
+    t.tesseract_calls += 1;
+}
+
+pub fn preprocess(t: &mut Timings, d: Duration) {
+    t.preprocess += d;
+}
+
+pub fn poppler(t: &mut Timings, d: Duration) {
+    t.poppler += d;
+}

--- a/tests/bench_synth.rs
+++ b/tests/bench_synth.rs
@@ -1,0 +1,121 @@
+//! Non-régression sur corpus synthétique.
+//!
+//! Ce test valide la chaîne complète — génération, vérité terrain, mesure — sur des
+//! documents fictifs, sans jamais toucher au corpus réel. Il est cantonné aux PDF
+//! natifs pour rester exécutable en intégration continue : les variantes scannées
+//! demandent tesseract et les modèles ocrs, absents de l'image de CI. Le volet OCR est
+//! couvert par `full_corpus_meets_a_floor`, marqué `#[ignore]`.
+
+use std::path::{Path, PathBuf};
+
+use la_taupe::bench::{self, truth::TruthSet};
+use la_taupe::synth;
+
+/// Les cinq premiers documents de la grille sont les PDF natifs, un par gabarit.
+const NATIVE_PDF_COUNT: usize = 5;
+
+fn corpus_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("la_taupe_bench_{}", name));
+    std::fs::remove_dir_all(&dir).ok();
+    dir
+}
+
+fn measure(dir: &Path, count: Option<usize>) -> bench::report::Report {
+    synth::write(dir, 7, count).expect("écriture du corpus");
+
+    let truths = TruthSet::load(&dir.join("truth.csv")).expect("vérité terrain");
+
+    bench::run(dir, &truths, true, 4).expect("exécution du banc")
+}
+
+/// Sur PDF natif, aucune reconnaissance n'est en jeu : tout doit être exact. Un échec
+/// ici signale une régression de `Rib::parse` ou un gabarit devenu irréaliste.
+#[test]
+fn native_pdfs_are_fully_recognised() {
+    let dir = corpus_dir("native");
+    let report = measure(&dir, Some(NATIVE_PDF_COUNT));
+
+    assert_eq!(report.files.len(), NATIVE_PDF_COUNT);
+
+    for file in &report.files {
+        assert!(
+            file.iban.is_ok(),
+            "IBAN non reconnu sur {} (verdict {})",
+            file.file,
+            file.iban.as_str()
+        );
+        assert!(
+            file.bic.is_ok(),
+            "BIC non reconnu sur {} (verdict {})",
+            file.file,
+            file.bic.as_str()
+        );
+        assert!(
+            file.holder_loose.is_ok(),
+            "titulaire non reconnu sur {} (verdict {})",
+            file.file,
+            file.holder_loose.as_str()
+        );
+        assert_eq!(file.engine, Some("pdf_text"));
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Le rapport ne doit jamais laisser fuiter le contenu des documents. On le vérifie sur
+/// des données fictives, mais la propriété testée vaut pour le corpus réel.
+#[test]
+fn the_report_never_leaks_document_content() {
+    let dir = corpus_dir("leak");
+    let report = measure(&dir, Some(NATIVE_PDF_COUNT));
+
+    let truths = TruthSet::load(&dir.join("truth.csv")).expect("vérité terrain");
+    let rendered = format!("{}{}", report.render_files(), report.render_summary());
+
+    for file in &report.files {
+        let truth = truths.get(&file.file).expect("ligne de vérité");
+
+        let iban = truth.iban.as_ref().expect("IBAN attendu");
+        assert!(
+            !rendered.contains(iban.as_str()),
+            "l'IBAN de {} figure dans le rapport",
+            file.file
+        );
+
+        for line in truth.holder.as_ref().expect("titulaire attendu").lines() {
+            assert!(
+                !rendered.contains(line),
+                "le titulaire de {} figure dans le rapport",
+                file.file
+            );
+        }
+    }
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Mesure de bout en bout, OCR compris. Demande tesseract et les modèles ocrs :
+///
+///     cargo test --release --features bench --test bench_synth -- --ignored --nocapture
+#[test]
+#[ignore]
+fn full_corpus_meets_a_floor() {
+    let dir = corpus_dir("full");
+    let report = measure(&dir, None);
+
+    println!("{}", report.render_files());
+    println!("{}", report.render_summary());
+
+    let measurable: Vec<_> = report.files.iter().filter(|f| !f.known_failure).collect();
+    let recognised = measurable.iter().filter(|f| f.iban.is_ok()).count();
+    let rate = recognised as f32 / measurable.len() as f32;
+
+    // plancher volontairement bas : il protège d'un effondrement, pas d'une variation
+    assert!(
+        rate >= 0.80,
+        "taux de reconnaissance IBAN tombé à {:.1} %",
+        rate * 100.0
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Stacked on #58.

A measurement bench for RIB recognition, behind the `bench` feature — zero impact on the production binary.

**Privacy by construction.** The bench runs the production pipeline on a corpus against a ground-truth CSV that never leaves the machine, and reports only verdicts and geometric/timing figures. A `FileReport` carries no recognised text; a test checks the report leaks nothing. The real corpus of personal RIBs was measured throughout without anyone but its owner ever reading it.

```
cargo run --release --features bench --bin bench -- --corpus <dir> [--profile] [--confusion] [--check]
cargo run --release --features bench --bin synth -- --out <dir> [--seed N]
```

- per document: IBAN / BIC / holder verdicts (strict, loose, content), nature of a wrong holder (truncated / overflowing / city / street / name±1 / name wrong), route, winning strategy, anchor, second pass, time split ocrs/tesseract/preprocessing/poppler
- `--profile`: shape statistics of the recognised text by verdict — this is what showed synthetic failures did not look like real ones
- `--check` validates a hand-written truth file; `--bootstrap` seeds one from double-checksummed IBANs
- synthetic corpus: fictional RIBs on seven layouts copied from real fixtures, as native PDF / scanned PDF / photos, with seeded degradations; composition follows what the service actually receives
- `tests/bench_synth.rs` runs in CI on native PDFs and checks the no-leak property

**Measure one job at a time** (`--jobs 1`); the noise margin is ±3 (two toolchains read the same crop 1–2 characters apart). See README.

MSRV unchanged (1.86).