### PR TITLE
feat(cli): batch RIB analysis of files and directories

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,11 @@ use la_taupe::{
     twoddoc::trust_service,
 };
 use serde_json::json;
-use std::{env::args, path::Path};
+use std::{
+    env::args,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 fn main() {
     let args: Vec<String> = args().collect();
@@ -13,7 +17,9 @@ fn main() {
         println!("La taupe: a tool to analyze files");
         println!("--version to print the version");
         println!("--trusted-repositories-urls to print the trusted repository urls");
-        println!("la_taupe file_path to analyze a file");
+        println!("la_taupe file_path to analyze a file as a 2D-Doc");
+        println!("la_taupe --rib [--jobs N] path... to analyze files or directories as RIBs,");
+        println!("        one JSON line per file, with the analysis duration");
         println!("la_taupe to start the server");
         std::process::exit(0);
     }
@@ -29,6 +35,12 @@ fn main() {
             println!("{}", url);
         }
         std::process::exit(0);
+    }
+
+    if args.contains(&String::from("--rib")) {
+        env_logger::init();
+        analyze_ribs(&args);
+        return;
     }
 
     if args.len() == 1 {
@@ -57,4 +69,111 @@ fn main() {
             }
         });
     }
+}
+
+/// Batch RIB analysis: expands directories, analyzes `--jobs` files concurrently and
+/// prints one compact JSON line per file, so a driving script can stream the results.
+fn analyze_ribs(args: &[String]) {
+    let jobs = args
+        .iter()
+        .position(|arg| arg == "--jobs")
+        .and_then(|i| args.get(i + 1))
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1)
+        .max(1);
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    let mut jobs_value = false;
+    for arg in &args[1..] {
+        if jobs_value {
+            jobs_value = false;
+            continue;
+        }
+        if arg == "--jobs" {
+            jobs_value = true;
+            continue;
+        }
+        if arg.starts_with("--") {
+            continue;
+        }
+
+        match expand(Path::new(arg)) {
+            Ok(mut paths) => files.append(&mut paths),
+            Err(msg) => {
+                eprintln!("{}", msg);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if files.is_empty() {
+        eprintln!("--rib expects at least one file or directory");
+        std::process::exit(1);
+    }
+
+    let jobs = jobs.min(files.len());
+
+    std::thread::scope(|scope| {
+        for job in 0..jobs {
+            let files = &files;
+
+            scope.spawn(move || {
+                files.iter().skip(job).step_by(jobs).for_each(|path| {
+                    // println! locks stdout for the whole line: no interleaving
+                    println!("{}", analyze_one_rib(path));
+                });
+            });
+        }
+    });
+}
+
+/// Files of a directory (hidden ones excluded), sorted so two runs list them in the
+/// same order; a plain file is returned as is.
+fn expand(path: &Path) -> Result<Vec<PathBuf>, String> {
+    if !path.is_dir() {
+        return Ok(vec![path.to_path_buf()]);
+    }
+
+    let entries =
+        std::fs::read_dir(path).map_err(|e| format!("cannot read {}: {}", path.display(), e))?;
+
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| !name.starts_with('.'))
+                .unwrap_or(false)
+        })
+        .collect();
+
+    files.sort();
+
+    Ok(files)
+}
+
+/// One stubborn file must not sink a whole directory run: panics are caught and
+/// reported as an error line, like any other failure.
+fn analyze_one_rib(path: &Path) -> String {
+    let file_path = path.display().to_string();
+
+    let started = Instant::now();
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        Analysis::try_from((path, Some(Hint::Type(Type::Rib))))
+    }));
+    let duration_ms = started.elapsed().as_millis() as u64;
+
+    let line = match outcome {
+        Ok(Ok(analysis)) => {
+            json!({"file_path": file_path, "duration_ms": duration_ms, "analysis": analysis})
+        }
+        Ok(Err(msg)) => json!({"file_path": file_path, "duration_ms": duration_ms, "error": msg}),
+        Err(_) => {
+            json!({"file_path": file_path, "duration_ms": duration_ms, "error": "analysis panicked"})
+        }
+    };
+
+    serde_json::to_string(&line).unwrap()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,10 @@ fn main() {
         println!("La taupe: a tool to analyze files");
         println!("--version to print the version");
         println!("--trusted-repositories-urls to print the trusted repository urls");
-        println!("la_taupe file_path to analyze a file as a 2D-Doc");
-        println!("la_taupe --rib [--jobs N] path... to analyze files or directories as RIBs,");
-        println!("        one JSON line per file, with the analysis duration");
+        println!("la_taupe [--type rib|2ddoc] [--jobs N] path... to analyze files or");
+        println!("        directories, one JSON line per file, with the analysis duration.");
+        println!("        --type restricts the analysis, like the hint of the http api;");
+        println!("        without it both analyses run.");
         println!("la_taupe to start the server");
         std::process::exit(0);
     }
@@ -37,77 +38,59 @@ fn main() {
         std::process::exit(0);
     }
 
-    if args.contains(&String::from("--rib")) {
-        env_logger::init();
-        analyze_ribs(&args);
-        return;
-    }
-
     if args.len() == 1 {
         let _ = server::main();
     } else {
         env_logger::init();
-
-        let paths: Vec<&Path> = args[1..].iter().map(Path::new).collect();
-        paths.iter().for_each(|path| {
-            let result = Analysis::try_from((*path, Some(Hint::Type(Type::Twoddoc))));
-            match result {
-                Ok(analysis_result) => {
-                    let json = json!({
-                        "file_path": path.to_str().unwrap(),
-                        "analysis": analysis_result
-                    });
-                    println!("{}", serde_json::to_string_pretty(&json).unwrap());
-                }
-                Err(msg) => {
-                    let json = json!({
-                        "file_path": path.to_str().unwrap(),
-                        "error": msg
-                    });
-                    println!("{}", serde_json::to_string_pretty(&json).unwrap());
-                }
-            }
-        });
+        analyze_batch(&args);
     }
 }
 
-/// Batch RIB analysis: expands directories, analyzes `--jobs` files concurrently and
+/// Batch analysis: expands directories, analyzes `--jobs` files concurrently and
 /// prints one compact JSON line per file, so a driving script can stream the results.
-fn analyze_ribs(args: &[String]) {
-    let jobs = args
-        .iter()
-        .position(|arg| arg == "--jobs")
-        .and_then(|i| args.get(i + 1))
-        .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(1)
-        .max(1);
-
+/// `--type` mirrors the hint of the http api; without it both analyses run.
+fn analyze_batch(args: &[String]) {
+    let mut hint: Option<Hint> = None;
+    let mut jobs = 1;
     let mut files: Vec<PathBuf> = Vec::new();
-    let mut jobs_value = false;
-    for arg in &args[1..] {
-        if jobs_value {
-            jobs_value = false;
-            continue;
-        }
-        if arg == "--jobs" {
-            jobs_value = true;
-            continue;
-        }
-        if arg.starts_with("--") {
-            continue;
-        }
 
-        match expand(Path::new(arg)) {
-            Ok(mut paths) => files.append(&mut paths),
-            Err(msg) => {
-                eprintln!("{}", msg);
+    let mut iter = args[1..].iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--type" => match iter.next().map(String::as_str) {
+                Some("rib") => hint = Some(Hint::Type(Type::Rib)),
+                Some("2ddoc") => hint = Some(Hint::Type(Type::Twoddoc)),
+                other => {
+                    eprintln!(
+                        "--type expects rib or 2ddoc, got {}",
+                        other.unwrap_or("nothing")
+                    );
+                    std::process::exit(1);
+                }
+            },
+            "--jobs" => match iter.next().and_then(|value| value.parse::<usize>().ok()) {
+                Some(value) => jobs = value.max(1),
+                None => {
+                    eprintln!("--jobs expects a number");
+                    std::process::exit(1);
+                }
+            },
+            flag if flag.starts_with("--") => {
+                eprintln!("unknown flag {}", flag);
                 std::process::exit(1);
             }
+            path => match expand(Path::new(path)) {
+                Ok(mut paths) => files.append(&mut paths),
+                Err(msg) => {
+                    eprintln!("{}", msg);
+                    std::process::exit(1);
+                }
+            },
         }
     }
 
     if files.is_empty() {
-        eprintln!("--rib expects at least one file or directory");
+        eprintln!("expected at least one file or directory");
         std::process::exit(1);
     }
 
@@ -120,7 +103,7 @@ fn analyze_ribs(args: &[String]) {
             scope.spawn(move || {
                 files.iter().skip(job).step_by(jobs).for_each(|path| {
                     // println! locks stdout for the whole line: no interleaving
-                    println!("{}", analyze_one_rib(path));
+                    println!("{}", analyze_one(path, hint));
                 });
             });
         }
@@ -156,12 +139,12 @@ fn expand(path: &Path) -> Result<Vec<PathBuf>, String> {
 
 /// One stubborn file must not sink a whole directory run: panics are caught and
 /// reported as an error line, like any other failure.
-fn analyze_one_rib(path: &Path) -> String {
+fn analyze_one(path: &Path, hint: Option<Hint>) -> String {
     let file_path = path.display().to_string();
 
     let started = Instant::now();
     let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        Analysis::try_from((path, Some(Hint::Type(Type::Rib))))
+        Analysis::try_from((path, hint))
     }));
     let duration_ms = started.elapsed().as_millis() as u64;
 

--- a/src/text/communes.rs
+++ b/src/text/communes.rs
@@ -12,9 +12,11 @@
 //! colonnes code postal et libellé d'acheminement sont conservées — la forme postale en
 //! capitales sans accent, celle qu'un RIB imprime. Regénérer :
 //!
-//!     curl -fsSL https://data.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/raw \
-//!       | iconv -f LATIN1 -t UTF-8 | awk -F';' 'NR>1 {print $3";"$4}' | sort -u \
-//!       > src/code_postal_commune.csv
+//! ```text
+//! curl -fsSL https://data.laposte.fr/data-fair/api/v1/datasets/laposte-hexasmal/raw \
+//!   | iconv -f LATIN1 -t UTF-8 | awk -F';' 'NR>1 {print $3";"$4}' | sort -u \
+//!   > src/code_postal_commune.csv
+//! ```
 
 use std::collections::HashMap;
 use std::sync::OnceLock;


### PR DESCRIPTION
## What

`la_taupe [--type rib|2ddoc] [--jobs N] path...` analyzes each file — directories are expanded (hidden files excluded, sorted), `--jobs` sets how many files are analyzed concurrently — and prints **one compact JSON line per file**, with the analysis duration.

`--type` speaks the vocabulary of the http api: it restricts the analysis exactly like the `hint` of `/analyze`, and without it both analyses run, like a request without hint.

```
$ la_taupe --type rib --jobs 4 corpus/
{"analysis":{"hint":"rib","rib":{...}},"duration_ms":34,"file_path":"corpus/1.pdf"}
{"analysis":{"hint":"rib","rib":null,"unreadable":true},"duration_ms":1210,"file_path":"corpus/2.jpg"}
{"duration_ms":0,"error":"Unsupported file type: application/zip","file_path":"corpus/3.zip"}
```

Panics are caught per file and reported as an error line, like the Rust banc does: one stubborn document must not sink a whole directory run. Unknown flags are rejected instead of silently ignored.

## Why

Until now the CLI only exposed the 2D-Doc analysis: measuring the RIB pipeline of an arbitrary build meant booting the http server, serving the corpus over a local file server and POSTing urls. A benchmark runner can now point two builds at the same corpus directly and diff their output streams — no server, no timing skew from http.

Breaking change for the debug CLI only: `la_taupe file` used to pretty-print a 2D-Doc-only analysis; it now runs both analyses and prints one compact line, consistent with every other invocation. The server behaviour (no argument) is untouched.

## Also

First commit fixes `cargo test` on every checkout: the shell snippet in the communes module doc was picked up by rustdoc as a Rust doctest and failed to compile. It is now a `text` fence.